### PR TITLE
revise API: provide server_fingerprint with the requested hash and a lis...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+master
+* server_fingerprint authenticator which validates the server certificate based on a provided server_name * fingerprint list
+
 0.2.0 (2014-10-30):
 * expose Certificate.cert_hostnames, wildcard_matches
 * Certificate.verify_chain_of_trust and X509.authenticate both return now

--- a/lib/certificate.mli
+++ b/lib/certificate.mli
@@ -59,12 +59,13 @@ val verify_chain_of_trust :
   ?host:host -> ?time:float -> anchors:(certificate list) -> stack
   -> [ `Ok of certificate | `Fail of certificate_failure ]
 
+(** [trust_fingerprint ?time hash fingerprints stack] is [validation_result], where the certificate [stack] is verified (using same RFC5280 algorithm). Instead of trust anchors, a map from hostname to fingerprint is provided, where the certificate is checked against. Lookup in the fingerprint list is based on the provided host. If no host is provided, [validation_result] is [`Fail]. *)
+val trust_fingerprint :
+  ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash -> fingerprints:(string * Cstruct.t) list -> stack
+  -> [ `Ok of certificate | `Fail of certificate_failure ]
+
 (** [valid_cas ?time certificates] is [valid_certificates] which has filtered out those certificates which validity period does not contain [time]. Furthermore, X509v3 extensions are checked (basic constraints must be true). *)
 val valid_cas : ?time:float -> certificate list -> certificate list
-
-val trust_fingerprint :
-  ?host:host -> ?time:float -> server_fingerprint:Cstruct.t -> stack
-  -> [ `Ok of certificate | `Fail of certificate_failure ]
 
 (** [common_name_to_string certificate] is [common_name] which is the extracted common name from the subject *)
 val common_name_to_string         : certificate -> string

--- a/lib/x509.ml
+++ b/lib/x509.ml
@@ -13,6 +13,11 @@ module Cs = struct
   let ends_with cs target =
     let l1 = len cs and l2 = len target in
     l1 >= l2 && equal (sub cs (l1 - l2) l2) target
+
+  let hex_to_cs = of_hex
+
+  let dotted_hex_to_cs =
+    o hex_to_cs (String.map (function ':' -> ' ' | x -> x))
 end
 
 module Pem = struct
@@ -139,9 +144,9 @@ module Authenticator = struct
     fun ?host stack ->
       Certificate.verify_chain_of_trust ?host ?time ~anchors:cas stack
 
-  let server_fingerprint ?time ~server_fingerprint =
+  let server_fingerprint ?time ~hash ~fingerprints =
     fun ?host stack ->
-      Certificate.trust_fingerprint ?host ?time ~server_fingerprint stack
+      Certificate.trust_fingerprint ?host ?time ~hash ~fingerprints stack
 
   let null ?host:_ (c, _) = `Ok c
 

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1,5 +1,10 @@
 (** Modules for X509 (RFC5280) handling *)
 
+module Cs : sig
+  val hex_to_cs : string -> Cstruct.t
+  val dotted_hex_to_cs : string -> Cstruct.t
+end
+
 (** A parser for PEM files *)
 module Pem : sig
   (** [parse pem] is [(name * data) list], in which the [pem] is parsed into its components, each surrounded by [BEGIN name] and [END name]. The actual [data] is base64 decoded. *)
@@ -44,8 +49,8 @@ module Authenticator : sig
   (** [chain_of_trust ?time trust_anchors] is [authenticator], which uses the given [time] and set of [trust_anchors] to verify the certificate chain. This is an implementation of the algorithm in RFC5280. *)
   val chain_of_trust : ?time:float -> Cert.t list -> t
 
-  (** [server_fingerprint ?time server_fingerprint] is an [authenticator] which uses the given [time] to verify the certificate chain - if successful the SHA256 fingerprint of the server certificate is checked. *)
-  val server_fingerprint : ?time:float -> server_fingerprint:Cstruct.t -> t
+  (** [server_fingerprint ?time hash fingerprints] is an [authenticator] which uses the given [time] to verify the certificate chain - if successful the [hash] of the server certificate is checked against the entry in the fingerprint list. *)
+  val server_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash -> fingerprints:(string * Cstruct.t) list -> t
 
   (** [null] is [authenticator], which always returns [`Ok]. For testing purposes only. *)
   val null : t


### PR DESCRIPTION
...t of server_name \* fingerprint - also export hex_to_cs and dotted_hex_to_cs
