### PR TITLE
Fingerprint verification fixes

### DIFF
--- a/lib/certificate.ml
+++ b/lib/certificate.ml
@@ -450,17 +450,17 @@ let trust_fingerprint ?host ?time ~hash ~fingerprints (server, certs) =
   let res =
     match host with
     | None -> fail NoServerName
-    | Some (`Wildcard x)
-    | Some (`Strict x) -> Ok x >>= fun name ->
-    match certs with
-    | [] ->
-      ( match validate_time time server, validate_hostname server host with
-        | true , true  -> verify_fingerprint name cert_fp fingerprints
-        | false, _     -> fail (CertificateExpired server)
-        | _    , false -> fail (InvalidServerName server) )
-    | _ ->
-      verify_chain ?host ?time (server, certs) >>= fun _ ->
-      verify_fingerprint name cert_fp fingerprints
+    | Some (`Wildcard name)
+    | Some (`Strict name) ->
+      match certs with
+      | [] ->
+        ( match validate_time time server, validate_hostname server host with
+          | true , true  -> verify_fingerprint name cert_fp fingerprints
+          | false, _     -> fail (CertificateExpired server)
+          | _    , false -> fail (InvalidServerName server) )
+      | _ ->
+        verify_chain ?host ?time (server, certs) >>= fun _ ->
+        verify_fingerprint name cert_fp fingerprints
   in
   lower res
 

--- a/lib/certificate.mli
+++ b/lib/certificate.mli
@@ -23,7 +23,6 @@ val asn_of_cert : certificate -> Asn_grammars.certificate
 
 (** possible failures while validating a certificate chain *)
 type certificate_failure =
-  | InvalidFingerprint of certificate
   | InvalidSignature of certificate * certificate
   | CertificateExpired of certificate
   | InvalidExtensions of certificate
@@ -33,10 +32,12 @@ type certificate_failure =
   | NoTrustAnchor
   | InvalidServerExtensions of certificate
   | InvalidServerName of certificate
-  | NoServerName
   | InvalidCA of certificate
   | IssuerSubjectMismatch of certificate * certificate
   | AuthorityKeyIdSubjectKeyIdMismatch of certificate * certificate
+  | NoServerName
+  | ServerNameNotPresent
+  | InvalidFingerprint of certificate
 
 (** variant of different public key types of a certificate *)
 type key_type = [ `RSA | `DH | `ECDH | `ECDSA ]


### PR DESCRIPTION
- don't check extensions in self-signed certificates when TOFU
- extract verify_chain function to deduplicate code