### PR TITLE
Make the authenticator type manifest

### DIFF
--- a/lib/x509.ml
+++ b/lib/x509.ml
@@ -130,8 +130,6 @@ module Authenticator = struct
   type res = [ `Ok of Certificate.certificate option | `Fail of Certificate.certificate_failure ]
   type t = ?host:Certificate.host -> Certificate.certificate list -> res
 
-  let authenticate t ?host stack = t ?host stack
-
   (* XXX
    * Authenticator just hands off a list of certs. Should be indexed.
    * *)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -37,14 +37,13 @@ end
 
 (** The authenticator for a certificate chain *)
 module Authenticator : sig
-  (** abstract authenticator type *)
-  type t
 
-  (** result of an authentication, either [`Ok] with trust anchor or [`Fail] with a reason *)
+  (** Authentication decision, either [`Ok] with trust anchor or [`Fail] with a reason *)
   type res = [ `Ok of Certificate.certificate option | `Fail of Certificate.certificate_failure ]
 
-  (** [authenticate authenticator ?host stack] is [result], where the given [authenticator] verifies the certificate [stack], given an optional [host] name. *)
-  val authenticate : t -> ?host:Certificate.host -> Certificate.certificate list -> res
+  (** An authenticator is a function taking a hostname and a certificate stack
+      to an authentication decision. *)
+  type t = ?host:Certificate.host -> Certificate.certificate list -> res
 
   (** [chain_of_trust ?time trust_anchors] is [authenticator], which uses the given [time] and set of [trust_anchors] to verify the certificate chain. This is an implementation of the algorithm in RFC5280. *)
   val chain_of_trust : ?time:float -> Cert.t list -> t


### PR DESCRIPTION
As of right now, there is no need to have the `Authenticator.t` abstract. It just prevents people from writing their own.

If and when we come up with a neat algebra for authenticators, they can get abstract again.