### PR TITLE
provide sexp conversions of certificate_failure, also sth useful

### DIFF
--- a/lib/certificate.ml
+++ b/lib/certificate.ml
@@ -57,7 +57,9 @@ type certificate = {
 
 (* XXX Revisit this - would be lovely to dump the full ASN tree. *)
 let certificate_of_sexp _ = failwith "can't parse cert from sexps"
-let sexp_of_certificate _ = Sexplib.Sexp.Atom "-SOME-CERTIFICATE-"
+let sexp_of_certificate cert = Sexplib.Sexp.List
+    [ Sexplib.Sexp.Atom "CERTIFICATE" ;
+      Sexplib.Sexp.Atom (Cstruct.to_string (Hash.digest `SHA256 cert.raw)) ]
 
 let cs_of_cert  { raw ; _ } = raw
 let asn_of_cert { asn ; _ } = asn
@@ -86,6 +88,7 @@ type certificate_failure =
   | ServerNameNotPresent
   | InvalidFingerprint of certificate
   | NoCertificate
+with sexp
 
 type key_type = [ `RSA | `DH | `ECDH | `ECDSA ]
 

--- a/lib/certificate.mli
+++ b/lib/certificate.mli
@@ -1,7 +1,7 @@
 (** Certificate validation as described in RFC5280 and RFC6125. *)
 
 (** abstract type of a certificate *)
-type certificate
+type certificate with sexp
 
 (** strict or wildcard matching of a server name *)
 type host = [ `Strict of string | `Wildcard of string ]
@@ -33,6 +33,7 @@ type certificate_failure =
   | ServerNameNotPresent
   | InvalidFingerprint of certificate
   | NoCertificate
+with sexp
 
 (** variant of different public key types of a certificate *)
 type key_type = [ `RSA | `DH | `ECDH | `ECDSA ]


### PR DESCRIPTION
for marshalling a certificate (namely its SHA256 fingerprint)