### PR TITLE
Authenticator sexp

### DIFF
--- a/lib/x509.ml
+++ b/lib/x509.ml
@@ -148,5 +148,14 @@ module Authenticator = struct
 
   let null ?host:_ _ = `Ok None
 
+  open Sexplib
+
+  let t_of_sexp = function
+    | Sexp.Atom "NULL" -> null
+    | sexp ->
+        Conv.of_sexp_error "Authenticator.t_of_sexp: atom 'NULL' needed" sexp
+
+  let sexp_of_t _ = Sexp.Atom "NULL"
+
 end
 

--- a/lib/x509.ml
+++ b/lib/x509.ml
@@ -127,7 +127,11 @@ end
 
 module Authenticator = struct
 
-  type res = [ `Ok of Certificate.certificate option | `Fail of Certificate.certificate_failure ]
+  type res = [
+    `Ok   of Certificate.certificate option
+  | `Fail of Certificate.certificate_failure
+  ]
+
   type t = ?host:Certificate.host -> Certificate.certificate list -> res
 
   (* XXX

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -44,6 +44,7 @@ module Authenticator : sig
   (** An authenticator is a function taking a hostname and a certificate stack
       to an authentication decision. *)
   type t = ?host:Certificate.host -> Certificate.certificate list -> res
+    with sexp
 
   (** [chain_of_trust ?time trust_anchors] is [authenticator], which uses the given [time] and set of [trust_anchors] to verify the certificate chain. This is an implementation of the algorithm in RFC5280. *)
   val chain_of_trust : ?time:float -> Cert.t list -> t

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -39,7 +39,10 @@ end
 module Authenticator : sig
 
   (** Authentication decision, either [`Ok] with trust anchor or [`Fail] with a reason *)
-  type res = [ `Ok of Certificate.certificate option | `Fail of Certificate.certificate_failure ]
+  type res = [
+    `Ok   of Certificate.certificate option
+  | `Fail of Certificate.certificate_failure
+  ]
 
   (** An authenticator is a function taking a hostname and a certificate stack
       to an authentication decision. *)


### PR DESCRIPTION
`Authenticator.t` should do its own sexp conversions even if it's stubs.