### PR TITLE
add X509.CA.Util

### DIFF
--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -119,6 +119,9 @@ val subject : t -> distinguished_name
     certificate. *)
 val issuer : t -> distinguished_name
 
+(** [serial t] is [sn], the serial number of the certificate. *)
+val serial : t -> Z.t
+
 (** X.509v3 extensions *)
 module Extension : sig
 
@@ -232,6 +235,26 @@ module CA : sig
       signed with given private key and issuer; digest defaults to
       [`SHA256]. *)
   val sign : signing_request -> valid_from:Asn.Time.t -> valid_until:Asn.Time.t -> ?digest:Nocrypto.Hash.hash -> ?serial:Z.t -> ?extensions:(bool * Extension.t) list -> private_key -> distinguished_name -> t
+
+  module Util : sig
+
+      (** [extensions signing_request] return the list of
+          certificate requests extensions contained in [signing_request]. *)
+      val extensions: signing_request -> request_extensions list
+
+      (** The polymorphic variant of subject_key_id input *)
+      type input = [
+        | `CSR of signing_request
+        | `CERT of t
+      ]
+
+      (** [subject_key_id input] return the 160-bit SHA-1 hash
+          of the BIT STRING subjectPublicKey (excluding the tag, length, and
+          number of unused bits) for the publicKeyInfo in [input].
+
+          RFC 5280, 4.2.1.2., variant (1) *)
+      val subject_key_id: input -> Cstruct.t
+  end
 end
 
 (** Validation logic: error variant and functions. *)

--- a/lib/x509_ca.ml
+++ b/lib/x509_ca.ml
@@ -75,3 +75,25 @@ let sign signing_request
   } in
   let raw = certificate_to_cstruct asn in
   { asn ; raw }
+
+module Util = struct
+    let extensions signing_request =
+      let info = (fst signing_request).CertificateRequest.info in
+      info.CertificateRequest.extensions
+
+    type input = [
+      | `CSR of signing_request
+      | `CERT of t
+    ]
+
+    let key_id = function
+      | `RSA p -> Nocrypto.Hash.digest `SHA1 (PK.rsa_public_to_cstruct p)
+      | `EC_pub _ -> invalid_arg "ECDSA not implemented"
+
+    let subject_key_id = function
+      | `CSR csr ->
+         let info = (fst csr).CertificateRequest.info in
+         key_id info.CertificateRequest.public_key
+      | `CERT cert ->
+         key_id (public_key cert)
+end

--- a/lib/x509_certificate.ml
+++ b/lib/x509_certificate.ml
@@ -28,6 +28,8 @@ let issuer { asn ; _ } = asn.tbs_cert.issuer
 
 let subject { asn ; _ } = asn.tbs_cert.subject
 
+let serial { asn ; _ } = asn.tbs_cert.serial
+
 let distinguished_name_to_string = X509_types.dn_to_string
 
 let parse_certificate cs =


### PR DESCRIPTION
- expose X509.CA.signing_request request_extensions

- provide a way to calculate SubjectKeyIdentifier for `RSA public keys in
  X509.t and X509.CA.signing_request

- while there also expose serial of X509.t