### PR TITLE
expose certificate hash fingerprint in X509.fingerprint

### DIFF
--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -131,6 +131,10 @@ type distinguished_name = component list
     representation of the {{!distinguished_name}dn}. *)
 val distinguished_name_to_string : distinguished_name -> string
 
+(** [fingerprint cert hash] is [Cstruct.t],
+    a hash digest of [cert] produced by the [hash] algorithm *)
+val fingerprint : t -> Nocrypto.Hash.hash -> Cstruct.t
+
 (** [subject certificate] is [dn], the subject as
     {{!distinguished_name}dn} of the [certificate]. *)
 val subject : t -> distinguished_name

--- a/lib/x509_certificate.ml
+++ b/lib/x509_certificate.ml
@@ -22,6 +22,8 @@ type t = {
   raw : Cstruct.t
 }
 
+let fingerprint cert hash = Hash.digest hash cert.raw
+
 let issuer { asn ; _ } = asn.tbs_cert.issuer
 
 let subject { asn ; _ } = asn.tbs_cert.subject


### PR DESCRIPTION
This patch exposes the fingerprint of the hash of the X509.t certificate.
The user must specify the desired hashing algorithm.

```ocaml
(** [fingerprint cert hash] is [Cstruct.t],
    a hash digest of [cert] produced by the [hash] algorithm *)
val fingerprint : t -> Nocrypto.Hash.hash -> Cstruct.t
```
Example usage:
```ocaml
X509.fingerprint cert `SHA256
```