### PR TITLE
public key fingerprint

### DIFF
--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -378,18 +378,28 @@ module Validation : sig
   val verify_chain_of_trust :
     ?host:host -> ?time:float -> anchors:(t list) -> t list -> result
 
-  (** [trust_cert_fingerprint ~time ~hash ~fingerprints certificates] is
-      [result], the first element of [certificates] is verified
-      against the given [fingerprints] map (hostname to fingerprint).
-      The certificate has to be valid in the given [time].  If a
-      [host] is provided, the certificate is checked for this name.
-      The [`Wildcard hostname] of the fingerprint list must match the
-      name in the certificate, using {!hostnames}.  *)
+  (** [trust_cert_fingerprint ~time ~hash ~fingerprints certificates]
+      is [result], the first element of [certificates] is verified to
+      match the given [fingerprints] map (hostname to fingerprint)
+      using {!fingerprint}.  The certificate has to be valid in the
+      given [time].  If a [host] is provided, the certificate is
+      checked for this name.  The [`Wildcard hostname] of the
+      fingerprint list must match the name in the certificate, using
+      {!hostnames}.
+
+      @deprecated "Pin public keys, not certificates (use [trust_key_fingerprint] instead)." *)
   val trust_cert_fingerprint :
     ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> t list -> result
-    [@deprecated "Pin public keys, not certificates (use trust_key_fingerprint instead)."]
 
+  (** [trust_key_fingerprint ~time ~hash ~fingerprints certificates]
+      is [result], the first element of [certificates] is verified
+      against the given [fingerprints] map (hostname to public key
+      fingerprint) using {!key_fingerprint}.  The certificate has to
+      be valid in the given [time].  If a [host] is provided, the
+      certificate is checked for this name.  The [`Wildcard hostname]
+      of the fingerprint list must match the name in the certificate,
+      using {!hostnames}. *)
   val trust_key_fingerprint :
     ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> t list -> result
@@ -425,11 +435,17 @@ module Authenticator : sig
   (** [server_cert_fingerprint ~time hash fingerprints] is an
       [authenticator] which uses the given [time] and list of
       [fingerprints] to verify the first element of the certificate
-      chain, using {!Validation.trust_fingerprint}. *)
+      chain, using {!Validation.trust_cert_fingerprint}.
+
+      @deprecated "Pin public keys, not certificates (use [server_key_fingerprint] instead)." *)
   val server_cert_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> a
-    [@deprecated "Pin public keys, not certificates (use server_key_fingerprint instead)."]
 
+  (** [server_key_fingerprint ~time hash fingerprints] is an
+      [authenticator] which uses the given [time] and list of
+      [fingerprints] to verify that the fingerprint of the first
+      element of the certificate chain matches the given fingerprint,
+      using {!Validation.trust_key_fingerprint}. *)
   val server_key_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> a
 

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -378,6 +378,18 @@ module Validation : sig
   val verify_chain_of_trust :
     ?host:host -> ?time:float -> anchors:(t list) -> t list -> result
 
+  (** [trust_key_fingerprint ~time ~hash ~fingerprints certificates]
+      is [result], the first element of [certificates] is verified
+      against the given [fingerprints] map (hostname to public key
+      fingerprint) using {!key_fingerprint}.  The certificate has to
+      be valid in the given [time].  If a [host] is provided, the
+      certificate is checked for this name.  The [`Wildcard hostname]
+      of the fingerprint list must match the name in the certificate,
+      using {!hostnames}. *)
+  val trust_key_fingerprint :
+    ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash ->
+    fingerprints:(string * Cstruct.t) list -> t list -> result
+
   (** [trust_cert_fingerprint ~time ~hash ~fingerprints certificates]
       is [result], the first element of [certificates] is verified to
       match the given [fingerprints] map (hostname to fingerprint)
@@ -389,18 +401,6 @@ module Validation : sig
 
       @deprecated "Pin public keys, not certificates (use [trust_key_fingerprint] instead)." *)
   val trust_cert_fingerprint :
-    ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash ->
-    fingerprints:(string * Cstruct.t) list -> t list -> result
-
-  (** [trust_key_fingerprint ~time ~hash ~fingerprints certificates]
-      is [result], the first element of [certificates] is verified
-      against the given [fingerprints] map (hostname to public key
-      fingerprint) using {!key_fingerprint}.  The certificate has to
-      be valid in the given [time].  If a [host] is provided, the
-      certificate is checked for this name.  The [`Wildcard hostname]
-      of the fingerprint list must match the name in the certificate,
-      using {!hostnames}. *)
-  val trust_key_fingerprint :
     ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> t list -> result
 
@@ -432,6 +432,14 @@ module Authenticator : sig
       using {!Validation.verify_chain_of_trust}. *)
   val chain_of_trust : ?time:float -> t list -> a
 
+  (** [server_key_fingerprint ~time hash fingerprints] is an
+      [authenticator] which uses the given [time] and list of
+      [fingerprints] to verify that the fingerprint of the first
+      element of the certificate chain matches the given fingerprint,
+      using {!Validation.trust_key_fingerprint}. *)
+  val server_key_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
+    fingerprints:(string * Cstruct.t) list -> a
+
   (** [server_cert_fingerprint ~time hash fingerprints] is an
       [authenticator] which uses the given [time] and list of
       [fingerprints] to verify the first element of the certificate
@@ -439,14 +447,6 @@ module Authenticator : sig
 
       @deprecated "Pin public keys, not certificates (use [server_key_fingerprint] instead)." *)
   val server_cert_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
-    fingerprints:(string * Cstruct.t) list -> a
-
-  (** [server_key_fingerprint ~time hash fingerprints] is an
-      [authenticator] which uses the given [time] and list of
-      [fingerprints] to verify that the fingerprint of the first
-      element of the certificate chain matches the given fingerprint,
-      using {!Validation.trust_key_fingerprint}. *)
-  val server_key_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> a
 
   (** [null] is [authenticator], which always returns [`Ok]. (Useful

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -72,6 +72,12 @@ type public_key = [ `RSA of Nocrypto.Rsa.pub | `EC_pub of Asn.OID.t ]
     {{:https://tools.ietf.org/html/rfc5280#section-4.2.1.2}RFC5280, 4.2.1.2, variant (1)} *)
 val key_id: public_key -> Cstruct.t
 
+(** [key_fingerprint ?hash public_key] is [result], the hash (by
+    default SHA256) of the DER encoded public key (equivalent to
+    `openssl x509 -noout -pubkey | openssl pkey -pubin -outform DER |
+    openssl dgst -HASH`).  *)
+val key_fingerprint : ?hash:Nocrypto.Hash.hash -> public_key -> Cstruct.t
+
 (** The polymorphic variant of private keys, with
     {{:http://tools.ietf.org/html/rfc5208}PKCS 8}
     {{!Encoding.Pem.Private_key}encoding and decoding to PEM}. *)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -378,14 +378,14 @@ module Validation : sig
   val verify_chain_of_trust :
     ?host:host -> ?time:float -> anchors:(t list) -> t list -> result
 
-  (** [trust_fingerprint ~time ~hash ~fingerprints certificates] is
+  (** [trust_cert_fingerprint ~time ~hash ~fingerprints certificates] is
       [result], the first element of [certificates] is verified
       against the given [fingerprints] map (hostname to fingerprint).
       The certificate has to be valid in the given [time].  If a
       [host] is provided, the certificate is checked for this name.
       The [`Wildcard hostname] of the fingerprint list must match the
       name in the certificate, using {!hostnames}.  *)
-  val trust_fingerprint :
+  val trust_cert_fingerprint :
     ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> t list -> result
 
@@ -417,11 +417,11 @@ module Authenticator : sig
       using {!Validation.verify_chain_of_trust}. *)
   val chain_of_trust : ?time:float -> t list -> a
 
-  (** [server_fingerprint ~time hash fingerprints] is an
+  (** [server_cert_fingerprint ~time hash fingerprints] is an
       [authenticator] which uses the given [time] and list of
       [fingerprints] to verify the first element of the certificate
       chain, using {!Validation.trust_fingerprint}. *)
-  val server_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
+  val server_cert_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> a
 
   (** [null] is [authenticator], which always returns [`Ok]. (Useful

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -389,6 +389,10 @@ module Validation : sig
     ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> t list -> result
 
+  val trust_key_fingerprint :
+    ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash ->
+    fingerprints:(string * Cstruct.t) list -> t list -> result
+
   (** [valid_cas ~time certificates] is [valid_certificates], only
       those certificates whose validity period matches the given time,
       and the certificate must be eligible for acting as a CA
@@ -422,6 +426,9 @@ module Authenticator : sig
       [fingerprints] to verify the first element of the certificate
       chain, using {!Validation.trust_fingerprint}. *)
   val server_cert_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
+    fingerprints:(string * Cstruct.t) list -> a
+
+  val server_key_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> a
 
   (** [null] is [authenticator], which always returns [`Ok]. (Useful

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -388,6 +388,7 @@ module Validation : sig
   val trust_cert_fingerprint :
     ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> t list -> result
+    [@deprecated "Pin public keys, not certificates (use trust_key_fingerprint instead)."]
 
   val trust_key_fingerprint :
     ?host:host -> ?time:float -> hash:Nocrypto.Hash.hash ->
@@ -427,6 +428,7 @@ module Authenticator : sig
       chain, using {!Validation.trust_fingerprint}. *)
   val server_cert_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> a
+    [@deprecated "Pin public keys, not certificates (use server_key_fingerprint instead)."]
 
   val server_key_fingerprint : ?time:float -> hash:Nocrypto.Hash.hash ->
     fingerprints:(string * Cstruct.t) list -> a

--- a/lib/x509_authenticator.ml
+++ b/lib/x509_authenticator.ml
@@ -15,9 +15,9 @@ let chain_of_trust ?time cas =
   fun ?host certificates ->
     Validation.verify_chain_of_trust ?host ?time ~anchors:cas certificates
 
-let server_fingerprint ?time ~hash ~fingerprints =
+let server_cert_fingerprint ?time ~hash ~fingerprints =
   fun ?host certificates ->
-    Validation.trust_fingerprint ?host ?time ~hash ~fingerprints certificates
+    Validation.trust_cert_fingerprint ?host ?time ~hash ~fingerprints certificates
 
 let null ?host:_ _ = `Ok None
 

--- a/lib/x509_authenticator.ml
+++ b/lib/x509_authenticator.ml
@@ -19,6 +19,10 @@ let server_cert_fingerprint ?time ~hash ~fingerprints =
   fun ?host certificates ->
     Validation.trust_cert_fingerprint ?host ?time ~hash ~fingerprints certificates
 
+let server_key_fingerprint ?time ~hash ~fingerprints =
+  fun ?host certificates ->
+    Validation.trust_key_fingerprint ?host ?time ~hash ~fingerprints certificates
+
 let null ?host:_ _ = `Ok None
 
 open Sexplib

--- a/lib/x509_authenticator.ml
+++ b/lib/x509_authenticator.ml
@@ -15,13 +15,13 @@ let chain_of_trust ?time cas =
   fun ?host certificates ->
     Validation.verify_chain_of_trust ?host ?time ~anchors:cas certificates
 
-let server_cert_fingerprint ?time ~hash ~fingerprints =
-  fun ?host certificates ->
-    Validation.trust_cert_fingerprint ?host ?time ~hash ~fingerprints certificates
-
 let server_key_fingerprint ?time ~hash ~fingerprints =
   fun ?host certificates ->
     Validation.trust_key_fingerprint ?host ?time ~hash ~fingerprints certificates
+
+let server_cert_fingerprint ?time ~hash ~fingerprints =
+  fun ?host certificates ->
+    Validation.trust_cert_fingerprint ?host ?time ~hash ~fingerprints certificates
 
 let null ?host:_ _ = `Ok None
 

--- a/lib/x509_certificate.ml
+++ b/lib/x509_certificate.ml
@@ -66,6 +66,9 @@ let key_id = function
   | `RSA p -> Hash.digest `SHA1 (PK.rsa_public_to_cstruct p)
   | `EC_pub _ -> invalid_arg "ECDSA not implemented"
 
+let key_fingerprint ?(hash = `SHA256) pub =
+  Hash.digest hash (Asn_grammars.PK.pub_info_to_cstruct pub)
+
 let private_key_to_keytype = function
   | `RSA _ -> `RSA
 

--- a/lib/x509_certificate.ml
+++ b/lib/x509_certificate.ml
@@ -519,12 +519,12 @@ module Validation = struct
       in
       lower res
 
-  let trust_cert_fingerprint ?host ?time ~hash ~fingerprints =
-    let fp = fingerprint hash in
-    fingerprint_verification ?host ?time fingerprints fp
-
   let trust_key_fingerprint ?host ?time ~hash ~fingerprints =
     let fp cert = key_fingerprint ~hash (public_key cert) in
+    fingerprint_verification ?host ?time fingerprints fp
+
+  let trust_cert_fingerprint ?host ?time ~hash ~fingerprints =
+    let fp = fingerprint hash in
     fingerprint_verification ?host ?time fingerprints fp
 
 end

--- a/lib/x509_certificate.ml
+++ b/lib/x509_certificate.ml
@@ -491,18 +491,18 @@ module Validation = struct
       (fun cert -> is_success @@ is_ca_cert_valid time cert)
       cas
 
-  let trust_cert_fingerprint ?host ?time ~hash ~fingerprints =
+  let fingerprint_verification ?host ?time fingerprints fp =
     function
     | [] -> `Fail `EmptyCertificateChain
     | server::_ ->
       let verify_fingerprint server fingerprints =
-        let cert_fp = fingerprint hash server in
-        (try Ok (List.find (fun (_, fp) -> Uncommon.Cs.equal fp cert_fp) fingerprints)
+        let fingerprint = fp server in
+        (try Ok (List.find (fun (_, fp) -> Uncommon.Cs.equal fp fingerprint) fingerprints)
          with Not_found ->
            try
              let tst = supports_hostname server in
              let f = List.find (fun (n, _) -> tst (`Wildcard n)) fingerprints in
-             fail (`InvalidFingerprint (server, cert_fp, snd f))
+             fail (`InvalidFingerprint (server, fingerprint, snd f))
            with Not_found -> fail (`ServerNameNotPresent (server, common_name_to_string server))
         ) >>= fun (name, _) ->
         if maybe_validate_hostname server (Some (`Wildcard name)) then
@@ -518,6 +518,14 @@ module Validation = struct
         | _    , false -> fail (`InvalidServerName (server, host))
       in
       lower res
+
+  let trust_cert_fingerprint ?host ?time ~hash ~fingerprints =
+    let fp = fingerprint hash in
+    fingerprint_verification ?host ?time fingerprints fp
+
+  let trust_key_fingerprint ?host ?time ~hash ~fingerprints =
+    let fp cert = key_fingerprint ~hash (public_key cert) in
+    fingerprint_verification ?host ?time fingerprints fp
 
 end
 

--- a/lib/x509_certificate.ml
+++ b/lib/x509_certificate.ml
@@ -491,7 +491,7 @@ module Validation = struct
       (fun cert -> is_success @@ is_ca_cert_valid time cert)
       cas
 
-  let trust_fingerprint ?host ?time ~hash ~fingerprints =
+  let trust_cert_fingerprint ?host ?time ~hash ~fingerprints =
     function
     | [] -> `Fail `EmptyCertificateChain
     | server::_ ->

--- a/lib/x509_certificate.ml
+++ b/lib/x509_certificate.ml
@@ -496,7 +496,7 @@ module Validation = struct
     | [] -> `Fail `EmptyCertificateChain
     | server::_ ->
       let verify_fingerprint server fingerprints =
-        let cert_fp = Hash.digest hash server.raw in
+        let cert_fp = fingerprint hash server in
         (try Ok (List.find (fun (_, fp) -> Uncommon.Cs.equal fp cert_fp) fingerprints)
          with Not_found ->
            try


### PR DESCRIPTION
instead of pinning certificates, allow pinning of public keys of leaf certificates (leaving certificate pinning around, but marked as deprecated, to be removed in next major release). addresses #68.  Also introduces `key_fingerprint : ?hash -> public_key -> Cstruct.t`, which produces the digest of the DER encoded public key (including algorithmIdentifier etc, thus unfortunately different from `key_id`, what a mess)