### PR TITLE
instead of requiring the certificate chain in the correct order,

### DIFF
--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -358,9 +358,9 @@ module Validation : sig
 
   (** {2 Validation functions} *)
 
-  (** The result of a validation: either success (optionally returning the used trust anchor), or failure *)
+  (** The result of a validation: either success (optionally returning the certificate chain and trust anchor), or failure *)
   type result = [
-    | `Ok of t option
+    | `Ok of (t list * t) option
     | `Fail of validation_error
   ]
 

--- a/tests/x509tests.ml
+++ b/tests/x509tests.ml
@@ -290,7 +290,7 @@ let invalid_tests =
     "no trust anchor" >:: strict_test_valid_ca_cert c [im_cert "cacert"] false h [] ;
     "2chain" >:: strict_test_valid_ca_cert c [im_cert "cacert" ; cacert] true h [cacert] ;
     "3chain" >:: strict_test_valid_ca_cert c [im_cert "cacert" ; cacert ; cacert] true h [cacert] ;
-    "no-chain" >:: strict_test_valid_ca_cert c [im_cert "cacert" ; im_cert "cacert" ; cacert] false h [cacert] ;
+    "no-chain" >:: strict_test_valid_ca_cert c [im_cert "cacert" ; im_cert "cacert" ; cacert] true h [cacert] ;
     "not a CA" >:: (fun _ -> assert_equal (List.length (Validation.valid_cas [im_cert "cacert"])) 0) ;
     "not a CA" >:: (fun _ -> assert_equal (List.length (Validation.valid_cas [c])) 0) ;
   ]


### PR DESCRIPTION
relax the ordering of intermediate certificates slightly:
- first, get rid of all expired intermediate certificates
- require server certificate to be first
- use a depth-first search for the intermediate certificates
  (any intermediate whose subject is the issuer of current is applicable)
- verify that the certificate is valid (signs current, pathlen)

also, as soon as there is a trust anchor which signs the chain,
report success.

notes:
- this change implements path building of RFC4158
- more certificate chains are accepted
- only those certificates used in the chain need to be valid
  (you can send [server; IM1; IM2; TA; XX; YY] where XX and YY
   are invalid certificates)
- the test of sending a broken chain [S; IM1; IM1; CA] now
  validates (since the second IM1 is ignored)

this addresses #51 and #53