### PR TITLE
Certificate ordering

### DIFF
--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -459,7 +459,7 @@ module Validation : sig
 
   (** The result of a validation: either success (optionally returning the used trust anchor), or failure *)
   type result = [
-    | `Ok of t option
+    | `Ok of (t list * t) option
     | `Fail of validation_error
   ]
 
@@ -468,7 +468,8 @@ module Validation : sig
       function, the first certificate of the chain is verified to be a valid
       leaf certificate (no BasicConstraints extension) and contains the given
       [host] (using {!hostnames}); if some path is valid, using {!verify_chain},
-      the result will be [Ok] and contain the used trust anchor. *)
+      the result will be [Ok] and contain the actual certificate chain and the
+      trust anchor. *)
   val verify_chain_of_trust :
     ?host:host -> ?time:float -> anchors:(t list) -> t list -> result
 

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -328,23 +328,28 @@ module Validation : sig
 
   (** {2 Validation failure} *)
 
+  (** The polymorphic variant of a leaf certificate validation error. *)
+  type leaf_validation_error = [
+    | `LeafCertificateExpired of t * float option
+    | `LeafInvalidName of t * host option
+    | `LeafInvalidVersion of t
+    | `LeafInvalidExtensions of t
+  ]
+
+  (** The polymorphic variant of a fingerprint validation error. *)
+  type fingerprint_validation_error = [
+    | `ServerNameNotPresent of t * string
+    | `NameNotInList of t
+    | `InvalidFingerprint of t * Cstruct.t * Cstruct.t
+  ]
+
   (** The polymorphic variant of validation errors. *)
   type validation_error = [
-    | `InvalidSignature of t * t
-    | `CertificateExpired of t * float option
-    | `InvalidExtensions of t
-    | `InvalidVersion of t
-    | `InvalidPathlen of t * int
-    | `SelfSigned of t
     | `NoTrustAnchor
-    | `InvalidServerExtensions of t
-    | `InvalidServerName of t * host option
-    | `InvalidCA of t
-    | `IssuerSubjectMismatch of t * t
-    | `AuthorityKeyIdSubjectKeyIdMismatch of t * t
-    | `ServerNameNotPresent of t * string
-    | `InvalidFingerprint of t * Cstruct.t * Cstruct.t
     | `EmptyCertificateChain
+    | `InvalidChain
+    | `Leaf of leaf_validation_error
+    | `Fingerprint of fingerprint_validation_error
   ]
 
   (** [validation_error_of_sexp sexp] is [validation_error], the unmarshalled [sexp]. *)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -345,7 +345,6 @@ module Validation : sig
 
   (** The polymorphic variant of validation errors. *)
   type validation_error = [
-    | `NoTrustAnchor
     | `EmptyCertificateChain
     | `InvalidChain
     | `Leaf of leaf_validation_error

--- a/lib/x509_certificate.ml
+++ b/lib/x509_certificate.ml
@@ -588,14 +588,14 @@ module Validation = struct
        lower res
 
   type result = [
-    | `Ok   of t option
+    | `Ok   of (t list * t) option
     | `Fail of validation_error
   ]
 
   let rec any_m e f = function
     | [] -> Error e
     | c::cs -> match f c with
-               | Ok ta -> Ok (Some ta) (* inject c *)
+               | Ok ta -> Ok (Some (c, ta))
                | Error _ -> any_m e f cs
 
   let verify_chain_of_trust ?host ?time ~anchors = function

--- a/tests/regression.ml
+++ b/tests/regression.ml
@@ -13,7 +13,7 @@ let cacert = cert "cacert"
 
 let test_jc_jc _ =
   match Validation.verify_chain_of_trust ~host:(`Strict "jabber.ccc.de") ~anchors:[jc] [jc] with
-  | `Fail `NoTrustAnchor -> ()
+  | `Fail `InvalidChain -> ()
   | _ -> assert_failure ("something went wrong with jc_jc")
 
 let test_jc_ca _ =

--- a/tests/x509tests.ml
+++ b/tests/x509tests.ml
@@ -290,7 +290,7 @@ let invalid_tests =
     "no trust anchor" >:: strict_test_valid_ca_cert c [im_cert "cacert"] false h [] ;
     "2chain" >:: strict_test_valid_ca_cert c [im_cert "cacert" ; cacert] true h [cacert] ;
     "3chain" >:: strict_test_valid_ca_cert c [im_cert "cacert" ; cacert ; cacert] true h [cacert] ;
-    "no-chain" >:: strict_test_valid_ca_cert c [im_cert "cacert" ; im_cert "cacert" ; cacert] false h [cacert] ;
+    "chain-order" >:: strict_test_valid_ca_cert c [im_cert "cacert" ; im_cert "cacert" ; cacert] true h [cacert] ;
     "not a CA" >:: (fun _ -> assert_equal (List.length (Validation.valid_cas [im_cert "cacert"])) 0) ;
     "not a CA" >:: (fun _ -> assert_equal (List.length (Validation.valid_cas [c])) 0) ;
   ]


### PR DESCRIPTION
in congruence to the real world, this PR accepts arbitrarily ordered certificate chains, instead of requiring `server :: issuer_of_server :: issuer_of_issuer_of_server :: ... :: []`, where the last certificate is signed by some trust anchor.  In reality these aren't strict chains anymore (there are practical reasons, such as phasing out SHA1 and MD5 signatures, while preserving compatibility with deployed trust anchors; thus `S -> A -> B -> C -> D` might be transmitted, where `S` is the leaf certificate, signed by `A`, which is signed both by `B -> C` rooted in some arcane trust anchor, and also by `D`, rooted in some modern trust anchor).

This also implements the informational RFC 4158, how to build paths.  A potential user can build paths manually, and verify each in order to receive more detailed error messages.  By default (in `verify_chain_of_trust`) the result is either `Ok` or `Fail` with a `Leaf` problem, `EmptyCertificateChain` or `InvalidChain` (we lost fine-grained errors on the way).  A successful result contains also the chain which lead to this result.

Instead of a huge `validation_error` variant, this is now more fine-grained and respective functions return smaller variants.

Additionally, `valid_ca` is exposed to analyse whether the X.509 library accepts the given certificate as a certificate authority.