### PR TITLE
Add css_of_distinguished_name

### DIFF
--- a/lib/asn_grammars.ml
+++ b/lib/asn_grammars.ml
@@ -139,6 +139,9 @@ module Name = struct
     in
     rdn_sequence (* A vacuous choice, in the standard. *)
 
+  let (name_of_cstruct, name_to_cstruct) =
+    projections_of der name
+
   (* rfc5280 section 7.1. -- we're too strict on strings and should preserve the
    * order. *)
   let equal n1 n2 = compare_unordered_lists compare n1 n2 = 0

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -569,6 +569,10 @@ module Encoding : sig
       representation of the [certificate]. *)
   val cs_of_cert  : t -> Cstruct.t
 
+  (** [cs_of_distinguished_name dn] is [cstruct], the ASN.1 encoded
+      representation of the distinguished name [dn]. *)
+  val cs_of_distinguished_name : distinguished_name -> Cstruct.t
+
   (** [parse_signing_request cstruct] is [signing_request option],
       the ASN.1 decoded [cstruct] or [None]. *)
   val parse_signing_request : Cstruct.t -> CA.signing_request option

--- a/lib/x509_encoding.ml
+++ b/lib/x509_encoding.ml
@@ -1,6 +1,8 @@
 
 let cs_of_cert = X509_certificate.cs_of_cert
 
+let cs_of_distinguished_name = Asn_grammars.Name.name_to_cstruct
+
 let parse = X509_certificate.parse_certificate
 
 let parse_signing_request = X509_ca.parse_signing_request


### PR DESCRIPTION
This adds `X509.Encoding.cs_of_cert_subject` which is required for https://github.com/mirleft/ocaml-tls/pull/332