### PR TITLE
support `unsupported` extensions

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -1,4 +1,4 @@
-#require "asn1-combinators,nocrypto,cstruct,oUnit,bytes,sexplib";;
+#require "asn1-combinators,nocrypto,cstruct,oUnit,bytes,sexplib,astring";;
 
 #directory "_build/lib";;
 #load "x509.cma";;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PACKAGE="x509" PINS="nocrypto asn1-combinators"
+    - PACKAGE="x509"
 matrix:
   include:
   - os: linux

--- a/_tags
+++ b/_tags
@@ -5,6 +5,4 @@ true : package(asn1-combinators cstruct nocrypto sexplib astring)
 <lib> : include
 <lib/x509_certificate.ml> : package(ppx_sexp_conv)
 
-<tests/*> : package(oUnit)
-<tests/regression.ml> : package(cstruct.unix)
-<tests/unittestrunner.{ml,byte,native}> : package(cstruct.unix)
+<tests/*> : package(oUnit cstruct.unix)

--- a/lib/asn_grammars.ml
+++ b/lib/asn_grammars.ml
@@ -962,3 +962,10 @@ let  extn_subject_alt_name
   (f @@ function `Priv_key_period   _ as x -> Some x | _ -> None),
   (f @@ function `Name_constraints  _ as x -> Some x | _ -> None),
   (f @@ function `Policies          _ as x -> Some x | _ -> None)
+
+let extn_unknown cert oid =
+  List_ext.map_find cert.tbs_cert.extensions
+    ~f:(fun (crit, ext) ->
+        match ext with
+        | `Unsupported (o, v) when o = oid -> Some (crit, v)
+        | _ -> None)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -254,6 +254,9 @@ module Extension : sig
       [Some (crit, data)] if an extension with [oid] is present. *)
   val unsupported : t -> Asn.OID.t -> (bool * Cstruct.t) option
 
+  (** Returns [subject_alt_names] if extension if present, else [ [] ]. *)
+  val subject_alt_names : t -> general_name list
+
   (** The polymorphic variant of
   {{:https://tools.ietf.org/html/rfc5280#section-4.2}X509v3
   extensions}. *)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -250,6 +250,10 @@ module Extension : sig
   extension}. *)
   type policy = [ `Any | `Something of Asn.OID.t ]
 
+  (** [unsupported cert oid] is [None] if [oid] is not present as extension, or
+      [Some (crit, data)] if an extension with [oid] is present. *)
+  val unsupported : t -> Asn.OID.t -> (bool * Cstruct.t) option
+
   (** The polymorphic variant of
   {{:https://tools.ietf.org/html/rfc5280#section-4.2}X509v3
   extensions}. *)

--- a/lib/x509_certificate.ml
+++ b/lib/x509_certificate.ml
@@ -175,7 +175,9 @@ let validate_raw_signature raw signature_algo signature_val pk_info =
 let raw_cert_hack raw signature =
   let siglen = Cstruct.len signature in
   let off    = if siglen > 128 then 1 else 0 in
-  Cstruct.(sub raw 4 (len raw - (siglen + 4 + 19 + off)))
+  let snd    = Cstruct.get_uint8 raw 1 in
+  let lenl   = 2 + if 0x80 land snd = 0 then 0 else 0x7F land snd in
+  Cstruct.(sub raw lenl (len raw - (siglen + lenl + 19 + off)))
 
 let validate_signature { asn = trusted ; _ } cert =
   let tbs_raw = raw_cert_hack cert.raw cert.asn.signature_val in

--- a/lib/x509_extension.ml
+++ b/lib/x509_extension.ml
@@ -21,3 +21,5 @@ let supports_extended_usage ?(not_present = false) c u =
   match cert_extended_usage c with
   | Some x -> List.mem u x
   | None   -> not_present
+
+let unsupported { asn ; _ } oid = Asn_grammars.extn_unknown asn oid

--- a/lib/x509_extension.ml
+++ b/lib/x509_extension.ml
@@ -23,3 +23,8 @@ let supports_extended_usage ?(not_present = false) c u =
   | None   -> not_present
 
 let unsupported { asn ; _ } oid = Asn_grammars.extn_unknown asn oid
+
+let subject_alt_names { asn = cert } =
+  match Asn_grammars.extn_subject_alt_name cert with
+  | Some (_, `Subject_alt_name names) -> names
+  | _ -> []

--- a/opam
+++ b/opam
@@ -27,6 +27,7 @@ depends: [
   "nocrypto" {>= "0.5.3"}
   "astring"
   "ounit" {test}
+  "cstruct-unix" {test}
 ]
 
 tags: [ "org:mirage" ]

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Pure X.509 Public Key Infrastructure in OCaml"
-requires = "cstruct sexplib nocrypto asn1-combinators"
+requires = "cstruct sexplib nocrypto asn1-combinators astring"
 archive(byte) = "x509.cma"
 archive(native) = "x509.cmxa"
 plugin(byte) = "x509.cma"


### PR DESCRIPTION
this PR
a) provides a function to extract the unsupported extension (for unknown/unhandled OIDs)
b) fixes the raw_signature_hack to work with large certificates (where 4 bytes is not a good estimate for the length of the certificate) by peeking into the actual number.  of course this is still a hack, but a good improvement over the existing one