### PR TITLE
use distinguished_name, not X509_types.distinguished_name, in x509.mli

### DIFF
--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -275,14 +275,14 @@ module Extension : sig
       relative one using a distinguished name. *)
   type distribution_point_name =
     [ `Full of general_name list
-    | `Relative of X509_types.distinguished_name ]
+    | `Relative of distinguished_name ]
 
   (** Distribution point, consisting of an optional name, an optional list of
       allowed reasons, and an optional issuer. *)
   type distribution_point =
     distribution_point_name option *
     reason list option *
-    X509_types.distinguished_name option
+    distinguished_name option
 
   (** Returns [crl_distribution_points] if extension if present, else [ [] ]. *)
   val crl_distribution_points : t -> distribution_point list


### PR DESCRIPTION
`X509_types` is not exposed, so without this change users can't create `distribution_point_name`s or `distribution_point`s.