### PR TITLE
compatibility with ppx_sexp_conv > v0.11.0

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,0 +1,20 @@
+open Ocamlbuild_plugin
+
+let runtime_deps_of_ppx ppx =
+  (Findlib.query "ppx_sexp_conv").dependencies
+  |> List.filter_opt (fun { Findlib.name; _ } ->
+      if name = ppx || name = "ppx_deriving" then
+        None
+      else
+        Some name)
+
+let () = dispatch (function
+    | After_rules ->
+      let meta = "pkg/META" in
+      let meta_in = meta ^ ".in" in
+      rule meta ~dep:meta_in ~prod:meta (fun _ _ ->
+          let deps = String.concat " " (runtime_deps_of_ppx "ppx_sexp_conv") in
+          Echo([String.subst "PPX_SEXP_CONV_RUNTIME" deps
+                  (Pathname.read meta_in)],
+               meta))
+    | _ -> ())

--- a/opam
+++ b/opam
@@ -19,8 +19,8 @@ build-test: [
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
   "topkg" {build}
+  "ppx_sexp_conv"
   "result"
   "cstruct" {>= "1.6.0"}
   "sexplib"
@@ -30,6 +30,10 @@ depends: [
   "astring"
   "ounit" {test}
   "cstruct-unix" {test & >= "3.0.0"}
+]
+
+conflicts: [
+  "ppx_sexp_conv" {= "v0.11.0"}
 ]
 
 tags: [ "org:mirage" ]

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Pure X.509 Public Key Infrastructure in OCaml"
-requires = "result cstruct sexplib nocrypto asn1-combinators astring ptime"
+requires = "result cstruct sexplib nocrypto asn1-combinators astring ptime PPX_SEXP_CONV_RUNTIME"
 archive(byte) = "x509.cma"
 archive(native) = "x509.cmxa"
 plugin(byte) = "x509.cma"


### PR DESCRIPTION
this uses the same myocamlbuild as nocrypto + tls to support ppx_sexp_conv > v0.11.0 which inserted runtime dependencies.  this makes x509 fit for 4.07.0