### PR TITLE
Improve pretty-printer for DNs (RFC 4514 and OSF).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   It used to be an attribute (expressed as GADT) Gmap.t, but this representation
   did not conform to RFC 5280, reported by @paurkedal (#117, fixed by #118)
 * Now using Set.find_first_opt, which bumps lower OCaml bound to 4.05.0
+* Improved pretty-printing for DNs including RFC 4514 conformance (@paurkedal, #119).
 
 ## v0.7.1 (2019-08-09)
 

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -148,11 +148,14 @@ module Distinguished_name : sig
           designed by analogy to RFC4514, substituting slash for comma an
           semicolon, and may currently not be fully compliant with the OSF
           specifications.
+
       @param spacing
         Determines whether to add space around separators:
+
         - [`Tight] to not add any redundant space,
         - [`Medium] to add space after comma and around plus signs, and
         - [`Loose] to also add space around equality signs.
+
         This parameter is currently ignored for the OSF format.
 
       The pretty-printer can be wrapped in a box to control line breaking and

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -132,7 +132,41 @@ module Distinguished_name : sig
   (** [equal a b] is [true] if the distinguished names [a] and [b] are equal. *)
   val equal : t -> t -> bool
 
-  (** [pp ppf dn] pretty-prints the distinguished name. *)
+  (** [make_pp ()] creates a customized pretty-printer for {!t}.
+
+      @param format
+        Determines RDN order, escaping rules, and the default spacing:
+        - [`RFC4514] produces the
+          {{:https://tools.ietf.org/html/rfc4514}RFC4514}.
+          RDNs are written in reverse order of the ASN.1 representation and
+          spacing defaults to tight.
+        - [`OpenSSL] produces the a format similar to OpenSSL.  RDNs are written
+          in the order of the ASN.1 representation, and spacing defaults to
+          loose.
+        - [`OSF] emits RDNs in the order they occur in the ASN.1 representation,
+          each prefixed by a slashes, using tight spacing.  This format is
+          designed by analogy to RFC4514, substituting slash for comma an
+          semicolon, and may currently not be fully compliant with the OSF
+          specifications.
+      @param spacing
+        Determines whether to add space around separators:
+        - [`Tight] to not add any redundant space,
+        - [`Medium] to add space after comma and around plus signs, and
+        - [`Loose] to also add space around equality signs.
+        This parameter is currently ignored for the OSF format.
+
+      The pretty-printer can be wrapped in a box to control line breaking and
+      set it apart, otherwise the RDN components will flow with the surrounding
+      text. *)
+  val make_pp :
+    format: [`RFC4514 | `OpenSSL | `OSF] ->
+    ?spacing: [`Tight | `Medium | `Loose] ->
+    unit -> t Fmt.t
+
+  (** [pp ppf dn] pretty-prints the distinguished name. This is currently
+      [Fmt.hbox (make_pp ~format:`OSF ())]. If your application relies on the
+      precise format, it is advicable to create a custom formatter with
+      {!make_pp} to guard against future changes to the default format. *)
   val pp : t Fmt.t
 
   (** [decode_der cs] is [dn], the ASN.1 decoded distinguished name of [cs]. *)


### PR DESCRIPTION
This is my suggestion for an improved DN pretty-printing, with some reservations:

1. I still cannot find any specifications for the OSF DN format, so that was designed in analogy with the RFC format and what I know from working with such DNs.  The uncertain part is escaping rules.  I consequently switched the default `pp` to the RFC format.

2. It should be noted that openssl uses something which looks like RFC 4514 but prints the RDNs in opposite order, e.g. `openssl -issuer` of by own cert is `C = NL, ST = Noord-Holland, L = Amsterdam, O = TERENA, CN = TERENA eScience Personal CA 3`.  I think this is a source of ambiguity, since its hard for a parser to determine which order is used, apart from heuristics on certain attribute-types. The OpenSSL order would have been better, but section 2.2 states the opposite. I found [a stackoverflow entry][1] about it.

3. Since line breaks are allowed before RDNs, I inserted braking hints, but opted to wrap the default printer `pp` in a hbox to avoid surprises, e.g. when creating a string to pass to a configuration file.  When referring to a DNs within a text it is better to skip the box (and add < > quotes around it).

4. Section 2.4 says that the hex-encoding of the attribute value must be used if the attribute type is in dotted-decimal form. This makes sense, since one would usually use the dotted-decimal form for unknown attribute types, where one also cannot know that the value is a DictionaryString.

Given point 2, maybe we should be less insistent and let `make_pp` flexible enough to support the OpenSSL format, and maybe switch back `pp` to the OSF format, which is unambiguous.  A parser can easily distinguish OSF from one of the other formats due to the `/` prefix.

[1]: https://stackoverflow.com/questions/39837102/x-509-standard-set-of-attributes-order