### PR TITLE
Pretty printers for extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## development branch
 
+* export X509.Distinguished_name.common_name : t -> string option, which
+  extracts the common name of a distinguished name
 * Distinguished_name.t is now a Relative_distinguished_name.t list, a
   Relative_distinguished_name is a Set.S with element type attribute, a variant.
   It used to be an attribute (expressed as GADT) Gmap.t, but this representation

--- a/lib/certificate.ml
+++ b/lib/certificate.ml
@@ -216,19 +216,11 @@ let extensions { asn = cert ; _ } = cert.tbs_cert.extensions
    Section 6.4.3. *)
 let hostnames { asn = cert ; _ } =
   let subj =
-    let is_cn = function
-      | Distinguished_name.CN _ -> true
-      | _ -> false
-    in
-    List.fold_left (fun acc dn ->
-        match
-          Distinguished_name.Relative_distinguished_name.find_first_opt is_cn dn
-        with
-        | Some Distinguished_name.CN x -> (match Domain_name.of_string x with
-            | Ok d -> Domain_name.Set.singleton d
-            | Error _ -> Domain_name.Set.empty)
-        | _ -> acc)
-      Domain_name.Set.empty cert.tbs_cert.subject
+    match Distinguished_name.common_name cert.tbs_cert.subject with
+    | None -> Domain_name.Set.empty
+    | Some x -> match Domain_name.of_string x with
+      | Ok d -> Domain_name.Set.singleton d
+      | Error _ -> Domain_name.Set.empty
   in
   match Extension.(find Subject_alt_name cert.tbs_cert.extensions) with
   | None -> subj

--- a/lib/distinguished_name.ml
+++ b/lib/distinguished_name.ml
@@ -101,6 +101,14 @@ let pp ppf dn =
   in
   Fmt.(list ~sep:(unit "/") pp_rdn) ppf dn
 
+let common_name t =
+  let is_cn = function CN _ -> true | _ -> false
+  in
+  List.fold_left (fun acc dn ->
+      match Relative_distinguished_name.find_first_opt is_cn dn with
+      | Some CN x -> Some x | _ -> acc)
+    None t
+
 module Asn = struct
   open Asn.S
   open Asn_grammars

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -135,6 +135,10 @@ module Distinguished_name : sig
   (** [pp ppf dn] pretty-prints the distinguished name. *)
   val pp : t Fmt.t
 
+  (** [common_name t] is [Some x] if the distinguished name [t] contains a
+      [CN x], [None] otherwise. *)
+  val common_name : t -> string option
+
   (** [decode_der cs] is [dn], the ASN.1 decoded distinguished name of [cs]. *)
   val decode_der : Cstruct.t -> (t, [> R.msg ]) result
 


### PR DESCRIPTION
also expose `Distinguished_name.common_name : t -> string option` (I have some revdeps which use exactly this) //cc @paurkedal