### PR TITLE
hash algorithms used for signatures

### DIFF
--- a/lib/authenticator.ml
+++ b/lib/authenticator.ml
@@ -7,13 +7,14 @@ type t = ?host:[`host] Domain_name.t -> Certificate.t list -> Validation.r
    * Authenticator authenticates against time it was *created* at, not at the moment of
    * authentication. This has repercussions to long-lived authenticators; reconsider.
    * *)
-let chain_of_trust ?time ?(crls = []) cas =
+let chain_of_trust ?time ?crls ?(hash_whitelist = Validation.sha2) cas =
   let revoked = match crls with
-    | [] -> None
-    | crls -> Some (Crl.is_revoked crls)
+    | None -> None
+    | Some crls -> Some (Crl.is_revoked crls ~hash_whitelist)
   in
   fun ?host certificates ->
-    Validation.verify_chain_of_trust ?host ?time ?revoked ~anchors:cas certificates
+    Validation.verify_chain_of_trust ?host ?time ?revoked ~hash_whitelist
+      ~anchors:cas certificates
 
 let server_key_fingerprint ?time ~hash ~fingerprints =
   fun ?host certificates ->

--- a/lib/certificate.ml
+++ b/lib/certificate.ml
@@ -194,6 +194,9 @@ let serial { asn ; _ } = asn.tbs_cert.serial
 
 let validity { asn ; _ } = asn.tbs_cert.validity
 
+let signature_algorithm { asn ; _ } =
+  Algorithm.to_signature_algorithm asn.signature_algo
+
 let public_key { asn = cert ; _ } = cert.tbs_cert.pk_info
 
 let supports_keytype c t =

--- a/lib/crl.ml
+++ b/lib/crl.ml
@@ -121,11 +121,12 @@ let crl_number { asn ; _ } =
 let signature_algorithm { asn ; _ } =
   Algorithm.to_signature_algorithm asn.signature_algo
 
-let validate { raw ; asn } pub =
+let validate { raw ; asn } ?(hash_whitelist = Validation.sha2) pub =
   let tbs_raw = Validation.raw_cert_hack raw asn.signature_val in
-  Validation.validate_raw_signature tbs_raw asn.signature_algo asn.signature_val pub
+  Validation.validate_raw_signature hash_whitelist tbs_raw asn.signature_algo
+    asn.signature_val pub
 
-let verify ({ asn ; _ } as crl) ?time cert =
+let verify ({ asn ; _ } as crl) ?hash_whitelist ?time cert =
   Distinguished_name.equal asn.tbs_crl.issuer (Certificate.subject cert) &&
   (match time with
    | None -> true
@@ -133,18 +134,18 @@ let verify ({ asn ; _ } as crl) ?time cert =
                match asn.tbs_crl.next_update with
                | None -> true
                | Some y -> Ptime.is_earlier ~than:y x) &&
-  validate crl (Certificate.public_key cert)
+  validate ?hash_whitelist crl (Certificate.public_key cert)
 
 let reason (revoked : revoked_cert) =
   match Extension.(find Reason revoked.extensions) with
   | Some (_, x) -> Some x
   | None -> None
 
-let is_revoked (crls : t list) ~issuer:super ~cert =
+let is_revoked (crls : t list) ?hash_whitelist ~issuer:super ~cert =
   List.exists (fun crl ->
       if
         Distinguished_name.equal (Certificate.subject super) (issuer crl) &&
-        validate crl (Certificate.public_key super)
+        validate ?hash_whitelist crl (Certificate.public_key super)
       then
         try
           let entry = List.find

--- a/lib/crl.ml
+++ b/lib/crl.ml
@@ -118,6 +118,9 @@ let crl_number { asn ; _ } =
   | None -> None
   | Some (_, x) -> Some x
 
+let signature_algorithm { asn ; _ } =
+  Algorithm.to_signature_algorithm asn.signature_algo
+
 let validate { raw ; asn } pub =
   let tbs_raw = Validation.raw_cert_hack raw asn.signature_val in
   Validation.validate_raw_signature tbs_raw asn.signature_algo asn.signature_val pub

--- a/lib/signing_request.ml
+++ b/lib/signing_request.ml
@@ -119,6 +119,9 @@ let raw_sign raw digest key =
 
 let info { asn ; _ } = asn.info
 
+let signature_algorithm { asn ; _ } =
+  Algorithm.to_signature_algorithm asn.signature_algorithm
+
 let hostnames csr =
   let info = info csr in
   let subj =

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -393,6 +393,9 @@ module Certificate : sig
   (** [public_key certificate] is [pk], the public key of the [certificate]. *)
   val public_key : t -> Public_key.t
 
+  (** [signature_algorithm certificate] is the algorithm used for the signature. *)
+  val signature_algorithm : t -> ([ `RSA | `ECDSA ] * Nocrypto.Hash.hash) option
+
   (** The polymorphic variant for hostname validation. *)
   type host = [ `Strict | `Wildcard ] * [ `host ] Domain_name.t
 
@@ -483,6 +486,9 @@ module Signing_request : sig
   (** [info signing_request] is {!request_info}, the information inside the
       {!signing_request}. *)
   val info : t -> request_info
+
+  (** [signature_algorithm signing_request] is the algorithm used for the signature. *)
+  val signature_algorithm : t -> ([ `RSA | `ECDSA ] * Nocrypto.Hash.hash) option
 
   (** [hostnames signing_request] is the set of domain names this
       [signing_request] is requesting. This is either the content of the DNS
@@ -576,6 +582,9 @@ module CRL : sig
 
   (** [crl_number t] is the number of the CRL. *)
   val crl_number : t -> int option
+
+  (** [signature_algorithm t] is the algorithm used for the signature. *)
+  val signature_algorithm : t -> ([ `RSA | `ECDSA ] * Nocrypto.Hash.hash) option
 
   (** {1 Validation and verification of CRLs} *)
 

--- a/tests/crltests.ml
+++ b/tests/crltests.ml
@@ -18,13 +18,15 @@ let with_loaded_files file ~f =
   with e -> Unix.close fd1 ; Unix.close fd2 ;
     Alcotest.failf "exception %s" (Printexc.to_string e)
 
+let hash_whitelist = [ `SHA1 ; `SHA256 ; `SHA384 ; `SHA512 ]
+
 let one f () =
   with_loaded_files f ~f:(fun cert crl ->
       let open Rresult.R.Infix in
       Certificate.decode_pem cert >>= fun cert ->
       let pubkey = Certificate.public_key cert in
       CRL.decode_der crl >>= fun crl ->
-      if not (CRL.validate crl pubkey) then
+      if not (CRL.validate crl ~hash_whitelist pubkey) then
         Error (`Msg "couldn't verify cert")
       else
         Ok ())

--- a/tests/regression.ml
+++ b/tests/regression.ml
@@ -21,8 +21,13 @@ let test_jc_jc () =
                  Validation.pp_validation_error e
   | Ok _ -> Alcotest.fail "chain validated when it shouldn't"
 
-let test_jc_ca () =
+let test_jc_ca_fail () =
   match Validation.verify_chain_of_trust ~host:(host "jabber.ccc.de") ~anchors:[cacert] [jc ; cacert] with
+  | Error `InvalidChain -> ()
+  | _ -> Alcotest.fail "something went wrong with jc_ca"
+
+let test_jc_ca_all_hashes () =
+  match Validation.verify_chain_of_trust ~hash_whitelist:[`SHA1] ~host:(host "jabber.ccc.de") ~anchors:[cacert] [jc ; cacert] with
   | Ok _ -> ()
   | _ -> Alcotest.fail "something went wrong with jc_ca"
 
@@ -108,7 +113,8 @@ let test_distinguished_name_pp () =
 
 let regression_tests = [
   "RSA: key too small (jc_jc)", `Quick, test_jc_jc ;
-  "jc_ca", `Quick, test_jc_ca ;
+  "jc_ca", `Quick, test_jc_ca_fail ;
+  "jc_ca", `Quick, test_jc_ca_all_hashes ;
   "jfd_ca", `Quick, test_jfd_ca ;
   "jfd_ca'", `Quick, test_jfd_ca' ;
   "SAN dir explicit or implicit", `Quick, test_izenpe ;

--- a/tests/revoke.ml
+++ b/tests/revoke.ml
@@ -68,7 +68,7 @@ let crl () =
   let revoked = { CRL.serial ; date = now ; extensions = Extension.empty } in
   let extensions = Extension.(singleton CRL_number (false, 1)) in
   let crl = CRL.revoke ~issuer ~this_update:now ~extensions [revoked] capriv in
-  let revoked = CRL.is_revoked [crl] in
+  let revoked = CRL.is_revoked [crl] ?hash_whitelist:None in
   match Validation.verify_chain ~revoked ~anchors:[ca] [cert] with
   | Ok _ -> Alcotest.fail "expected revocation"
   | Error (`Chain (`Revoked _)) -> ()
@@ -95,7 +95,7 @@ let crl' () =
   let revoked = { CRL.serial ; date = now ; extensions = Extension.empty } in
   let extensions = Extension.(singleton CRL_number (false, 1)) in
   let crl = CRL.revoke ~issuer ~this_update:now ~extensions [revoked] capriv in
-  let revoked = CRL.is_revoked [crl] in
+  let revoked = CRL.is_revoked [crl] ?hash_whitelist:None in
   match Validation.verify_chain ~revoked ~anchors:[ca] [cert ; ica] with
   | Ok _ -> Alcotest.fail "expected revocation"
   | Error (`Chain (`Revoked _)) -> ()
@@ -111,7 +111,7 @@ let crl'leaf () =
   let revoked = { CRL.serial ; date = now ; extensions = Extension.empty } in
   let extensions = Extension.(singleton CRL_number (false, 1)) in
   let crl = CRL.revoke ~issuer ~this_update:now ~extensions [revoked] ipriv in
-  let revoked = CRL.is_revoked [crl] in
+  let revoked = CRL.is_revoked [crl] ?hash_whitelist:None in
   match Validation.verify_chain ~revoked ~anchors:[ca] [cert ; ica] with
   | Ok _ -> Alcotest.fail "expected revocation"
   | Error (`Chain (`Revoked _)) -> ()
@@ -127,7 +127,7 @@ let crl'leaf'wrong () =
   let revoked = { CRL.serial ; date = now ; extensions = Extension.empty } in
   let extensions = Extension.(singleton CRL_number (false, 1)) in
   let crl = CRL.revoke ~issuer ~this_update:now ~extensions [revoked] ipriv in
-  let revoked = CRL.is_revoked [crl] in
+  let revoked = CRL.is_revoked [crl] ?hash_whitelist:None in
   match Validation.verify_chain ~revoked ~anchors:[ca] [cert ; ica] with
   | Ok _ -> ()
   | Error _ -> Alcotest.fail "expected success!"
@@ -142,7 +142,7 @@ let verify'' () =
   let revoked = { CRL.serial ; date = now ; extensions = Extension.empty } in
   let extensions = Extension.(singleton CRL_number (false, 1)) in
   let crl = CRL.revoke ~issuer ~this_update:now ~extensions [revoked] capriv in
-  let revoked = CRL.is_revoked [crl] in
+  let revoked = CRL.is_revoked [crl] ?hash_whitelist:None in
   match Validation.verify_chain ~revoked ~anchors:[ca] [cert ; ica] with
   | Ok _ -> ()
   | Error _ -> Alcotest.fail "expected verify to succeed!"
@@ -158,7 +158,7 @@ let crl'' () =
   let revoked = { CRL.serial ; date = now ; extensions } in
   let extensions = Extension.(singleton CRL_number (false, 1)) in
   let crl = CRL.revoke ~issuer ~this_update:now ~extensions [revoked] capriv in
-  let revoked = CRL.is_revoked [crl] in
+  let revoked = CRL.is_revoked [crl] ?hash_whitelist:None in
   match Validation.verify_chain ~revoked ~anchors:[ca] [cert ; ica] with
   | Ok _ -> ()
   | Error _ -> Alcotest.fail "expected proper verification!"


### PR DESCRIPTION
fixes #123

for @psafont I added ``val signature_algorithm : t -> ([ `RSA | `ECDSA ] * Nocrypto.Hash.hash) option`` to the Certificate, Signing_request, and CRL modules. Does this suite you well?

The (chain) validation functions now receive an optional `hash_whitelist` argument, which the signature algorithm must match. The default is any SHA-2 algorithm (SHA256/SHA384/SHA512, _not_ SHA224 - seems to be rarely used, I could not see a reason to include it). The default for `valid_ca{,s}` is any hash algorithm (following what others are doing).

/cc @emillon @paurkedal for a quick round of review -- this certainly changes the behaviour of x509 & tls -- in a good way forward (rejecting weak algorithms by default).