### PR TITLE
expose more detailed signature errors

### DIFF
--- a/lib/certificate.ml
+++ b/lib/certificate.ml
@@ -163,12 +163,15 @@ let encode_pem_multiple cs =
 let pp_version ppf v =
   Fmt.string ppf (match v with `V1 -> "1" | `V2 -> "2" | `V3 -> "3")
 
+let pp_hash ppf hash =
+  Fmt.string ppf (match hash with
+      | `MD5 -> "MD5" | `SHA1 -> "SHA1" | `SHA224 -> "SHA224"
+      | `SHA256 -> "SHA256" | `SHA384 -> "SHA384" | `SHA512 -> "SHA512")
+
 let pp_sigalg ppf (asym, hash) =
-  Fmt.pf ppf "%s-%s"
+  Fmt.pf ppf "%s-%a"
     (match asym with `RSA -> "RSA" | `ECDSA -> "ECDSA")
-    (match hash with
-     | `MD5 -> "MD5" | `SHA1 -> "SHA1" | `SHA224 -> "SHA224"
-     | `SHA256 -> "SHA256" | `SHA384 -> "SHA384" | `SHA512 -> "SHA512")
+    pp_hash hash
 
 let pp ppf { asn ; _ } =
   let tbs = asn.tbs_cert in

--- a/lib/dune
+++ b/lib/dune
@@ -6,4 +6,4 @@
                   extension pem signing_request general_name host)
  (flags (:standard -safe-string))
  (libraries asn1-combinators rresult fmt ptime cstruct mirage-crypto
-            mirage-crypto-pk gmap domain-name base64))
+            mirage-crypto-pk gmap domain-name base64 logs))

--- a/lib/public_key.ml
+++ b/lib/public_key.ml
@@ -3,6 +3,8 @@ type t = [
   | `EC_pub of Asn.oid
 ]
 
+module Asn_oid = Asn.OID
+
 module Asn = struct
   open Asn_grammars
   open Asn.S
@@ -48,6 +50,10 @@ let id = function
 
 let fingerprint ?(hash = `SHA256) pub =
   Mirage_crypto.Hash.digest hash (Asn.pub_info_to_cstruct pub)
+
+let pp ppf = function
+  | `RSA _ as k -> Fmt.pf ppf "RSA %a" Cstruct.hexdump_pp (fingerprint k)
+  | `EC_pub oid -> Fmt.pf ppf "EC %a" Asn_oid.pp oid
 
 let encode_der = Asn.pub_info_to_cstruct
 

--- a/lib/signing_request.ml
+++ b/lib/signing_request.ml
@@ -111,11 +111,9 @@ module Asn = struct
     projections_of Asn.der signing_request
 end
 
-let raw_sign raw digest key =
-  let hash = Mirage_crypto.Hash.digest digest raw in
-  let sigval = Certificate.encode_pkcs1_digest_info (digest, hash) in
+let raw_sign raw hash key =
   match key with
-    | `RSA priv -> Mirage_crypto_pk.Rsa.PKCS1.sig_encode ~key:priv sigval
+  | `RSA priv -> Mirage_crypto_pk.Rsa.PKCS1.sign ~hash ~key:priv (`Message raw)
 
 let info { asn ; _ } = asn.info
 

--- a/lib/signing_request.ml
+++ b/lib/signing_request.ml
@@ -138,19 +138,18 @@ let hostnames csr =
     | Some names -> names
     | None -> subj
 
-let validate_signature hash { asn ; raw } =
+let validate_signature hash_whitelist { asn ; raw } =
   let raw_data = Validation.raw_cert_hack raw asn.signature in
-  Validation.validate_raw_signature hash raw_data asn.signature_algorithm
-    asn.signature asn.info.public_key
+  Validation.validate_raw_signature asn.info.subject hash_whitelist raw_data
+    asn.signature_algorithm asn.signature asn.info.public_key
 
 let decode_der ?(hash_whitelist = Validation.sha2) cs =
   let open Rresult.R.Infix in
   Asn_grammars.err_to_msg (Asn.signing_request_of_cs cs) >>= fun csr ->
   let csr = { raw = cs ; asn = csr } in
-  if validate_signature hash_whitelist csr then
-    Ok csr
-  else
-    Error (`Msg "couldn't validate signature")
+  Rresult.R.error_to_msg ~pp_error:Validation.pp_signature_error
+    (validate_signature hash_whitelist csr) >>| fun () ->
+  csr
 
 let encode_der { raw ; _ } = raw
 
@@ -184,31 +183,30 @@ let sign signing_request
     ?(serial = Mirage_crypto_pk.(Z_extra.gen_r Z.one Z.(one lsl 64)))
     ?(extensions = Extension.empty)
     key issuer =
-  if not (validate_signature hash_whitelist signing_request) then
-    Error (`Msg "could not validate signature of signing request")
-  else
-    let signature_algo =
-      Algorithm.of_signature_algorithm (Private_key.keytype key) digest
-    and info = signing_request.asn.info
-    in
-    let tbs_cert : Certificate.tBSCertificate = {
-      version = `V3 ;
-      serial ;
-      signature = signature_algo ;
-      issuer = issuer ;
-      validity = (valid_from, valid_until) ;
-      subject = info.subject ;
-      pk_info = info.public_key ;
-      issuer_id = None ;
-      subject_id = None ;
-      extensions
-    } in
-    let tbs_raw = Certificate.Asn.tbs_certificate_to_cstruct tbs_cert in
-    let signature_val = raw_sign tbs_raw digest key in
-    let asn = {
-      Certificate.tbs_cert ;
-      signature_algo ;
-      signature_val ;
-    } in
-    let raw = Certificate.Asn.certificate_to_cstruct asn in
-    Ok { Certificate.asn ; raw }
+  let open Rresult.R.Infix in
+  validate_signature hash_whitelist signing_request >>= fun () ->
+  let signature_algo =
+    Algorithm.of_signature_algorithm (Private_key.keytype key) digest
+  and info = signing_request.asn.info
+  in
+  let tbs_cert : Certificate.tBSCertificate = {
+    version = `V3 ;
+    serial ;
+    signature = signature_algo ;
+    issuer = issuer ;
+    validity = (valid_from, valid_until) ;
+    subject = info.subject ;
+    pk_info = info.public_key ;
+    issuer_id = None ;
+    subject_id = None ;
+    extensions
+  } in
+  let tbs_raw = Certificate.Asn.tbs_certificate_to_cstruct tbs_cert in
+  let signature_val = raw_sign tbs_raw digest key in
+  let asn = {
+    Certificate.tbs_cert ;
+    signature_algo ;
+    signature_val ;
+  } in
+  let raw = Certificate.Asn.certificate_to_cstruct asn in
+  Ok { Certificate.asn ; raw }

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -470,11 +470,8 @@ module Validation : sig
 
   (** The type of signature verification errors. *)
   type signature_error = [
-    | `Bad_pkcs1_signature of Distinguished_name.t * Cstruct.t
-    | `Hash_algorithm_mismatch of Distinguished_name.t * Mirage_crypto.Hash.hash * Mirage_crypto.Hash.hash
-    | `Hash_mismatch of Distinguished_name.t * Cstruct.t * Cstruct.t
+    | `Bad_pkcs1_signature of Distinguished_name.t
     | `Hash_not_whitelisted of Distinguished_name.t * Mirage_crypto.Hash.hash
-    | `Bad_pkcs1_digest_info of Distinguished_name.t * Cstruct.t
     | `Unsupported_keytype of Distinguished_name.t * Public_key.t
   ]
 

--- a/tests/crltests.ml
+++ b/tests/crltests.ml
@@ -26,10 +26,8 @@ let one f () =
       Certificate.decode_pem cert >>= fun cert ->
       let pubkey = Certificate.public_key cert in
       CRL.decode_der crl >>= fun crl ->
-      if not (CRL.validate crl ~hash_whitelist pubkey) then
-        Error (`Msg "couldn't verify cert")
-      else
-        Ok ())
+      Rresult.R.error_to_msg ~pp_error:Validation.pp_signature_error
+        (CRL.validate crl ~hash_whitelist pubkey))
 
 let crl_tests = [
   "CRL 1 is good", `Quick, one "1" ;

--- a/tests/regression.ml
+++ b/tests/regression.ml
@@ -149,7 +149,8 @@ let csr file =
   let data = cs_mmap ("./csr/" ^ file ^ ".pem") in
   match Signing_request.decode_pem data with
   | Ok csr -> csr
-  | Error (`Msg m) -> Alcotest.failf "signing request %s decoding error %s" file m
+  | Error (`Msg m) ->
+    Alcotest.failf "signing request %s decoding error %s" file m
 
 let csr_hostnames cert names () =
   Alcotest.check host_set_test __LOC__ (Signing_request.hostnames cert) names

--- a/tests/revoke.ml
+++ b/tests/revoke.ml
@@ -73,7 +73,7 @@ let crl () =
   let revoked = CRL.is_revoked [crl] ?hash_whitelist:None in
   match Validation.verify_chain ~host:None ~time ~revoked ~anchors:[ca] [cert] with
   | Ok _ -> Alcotest.fail "expected revocation"
-  | Error (`Chain (`Revoked _)) -> ()
+  | Error (`Revoked _) -> ()
   | Error _ -> Alcotest.fail "expected revoked failure!"
 
 let verify' () =
@@ -100,7 +100,7 @@ let crl' () =
   let revoked = CRL.is_revoked [crl] ?hash_whitelist:None in
   match Validation.verify_chain ~host:None ~time ~revoked ~anchors:[ca] [cert ; ica] with
   | Ok _ -> Alcotest.fail "expected revocation"
-  | Error (`Chain (`Revoked _)) -> ()
+  | Error (`Revoked _) -> ()
   | Error _ -> Alcotest.fail "expected revoked failure!"
 
 let crl'leaf () =
@@ -116,7 +116,7 @@ let crl'leaf () =
   let revoked = CRL.is_revoked [crl] ?hash_whitelist:None in
   match Validation.verify_chain ~host:None ~time ~revoked ~anchors:[ca] [cert ; ica] with
   | Ok _ -> Alcotest.fail "expected revocation"
-  | Error (`Chain (`Revoked _)) -> ()
+  | Error (`Revoked _) -> ()
   | Error _ -> Alcotest.fail "expected revoked failure!"
 
 let crl'leaf'wrong () =

--- a/x509.opam
+++ b/x509.opam
@@ -27,6 +27,7 @@ depends: [
   "mirage-crypto-rng" {with-test}
   "gmap" {>= "0.3.0"}
   "domain-name" {>= "0.3.0"}
+  "logs"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
also, even if hash_whitelist contains a weak algorithm, print a log message
(warning level) about the usage of the weak algorithm

//cc @cfcs -- we discussed this