### PR TITLE
Another attempt to implement pkcs12

### DIFF
--- a/lib/pkcs12.ml
+++ b/lib/pkcs12.ml
@@ -1,0 +1,328 @@
+(* pkcs12 https://tools.ietf.org/html/rfc7292
+ * pkcs7 https://tools.ietf.org/html/rfc2315
+ * pkcs8 https://tools.ietf.org/html/rfc5208
+ * pkcs9 https://tools.ietf.org/html/rfc2985
+ * x.509 https://tools.ietf.org/html/rfc5280
+ * https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf *)
+
+let src = Logs.Src.create "x509.pkcs12" ~doc:"X509 pkcs12"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Attribute = struct
+  open Asn.S
+  open Asn_grammars
+
+  (* PKCS12Attribute ::= SEQUENCE {
+   *     attrId      ATTRIBUTE.&id ({PKCS12AttrSet}),
+   *     attrValues  SET OF ATTRIBUTE.&Type ({PKCS12AttrSet}{@attrId})
+   * } -- This type is compatible with the X.500 type 'Attribute'
+   * 
+   * PKCS12AttrSet ATTRIBUTE ::= {
+   *     friendlyName |
+   *     localKeyId,
+   *     ... -- Other attributes are allowed
+   * } *)
+
+   (* friendlyName ATTRIBUTE ::= {
+    *         WITH SYNTAX BMPString (SIZE(1..pkcs-9-ub-friendlyName))
+    *         EQUALITY MATCHING RULE caseIgnoreMatch
+    *         SINGLE VALUE TRUE
+    *         ID pkcs-9-at-friendlyName
+    * }
+    * 
+    * localKeyId ATTRIBUTE ::= {
+    *         WITH SYNTAX OCTET STRING
+    *         EQUALITY MATCHING RULE octetStringMatch
+    *         SINGLE VALUE TRUE
+    *         ID pkcs-9-at-localKeyId
+    * } *)
+  type t =
+    | FriendlyName of string
+    | LocalKeyId of Cstruct.t
+
+  let attribute =
+    let default oid = Asn.(S.parse_error "Unknown attrId %a" OID.pp oid) in
+    let f =
+      let friendlyname = function
+        | `C1 hd::[] -> FriendlyName hd
+        | _ -> parse_error "Attribute friendlyName must be single"
+      in
+      let localkeyid = function
+        | `C2 hd::[] -> LocalKeyId hd
+        | _ -> parse_error "Attribute localKeyId must be single"
+      in
+      case_of_oid_f ~default [
+        Registry.PKCS9.friendly_name, friendlyname;
+        Registry.PKCS9.local_key_id, localkeyid;
+      ]
+    in
+    let g = function
+      | FriendlyName x ->
+        Registry.PKCS9.friendly_name, [`C1 x]
+      | LocalKeyId x ->
+        Registry.PKCS9.local_key_id, [`C2 x]
+    in
+    map f g @@
+    sequence2
+      (required ~label:"attrId" oid)
+      (required ~label:"attrValues" @@
+       set_of (choice2 bmp_string octet_string))
+end
+
+module SafeBag = struct
+  open Asn.S
+  open Asn_grammars
+
+  (* type cert_type =
+   *   | X509 of Cstruct.t (\* TODO *\)
+   *   | SDSI of string (\* TODO *\)
+   * 
+   * let cert_bag =
+   *   let default oid = Asn.(S.parse_error "Unknown certId %a" OID.pp oid) in
+   *   let f =
+   *     let x509 = function
+   *       | `C1 x -> X509 x
+   *       | _ -> parse_error "CertBag: expected x509Certificate"
+   *     in
+   *     let sdsi = function
+   *       | `C2 x -> SDSI x
+   *       | _ -> parse_error "CertBag: expected sdsiCertificate"
+   *     in
+   *     case_of_oid_f ~default [
+   *       Registry.PKCS12.x509_certificate, x509;
+   *       Registry.PKCS12.sdsi_certificate, sdsi;
+   *     ]
+   *   in
+   *   let g =
+   *     function
+   *     | X509 x -> Registry.PKCS12.x509_certificate, `C1 x
+   *     | SDSI x -> Registry.PKCS12.sdsi_certificate, `C2 x
+   *   in
+   *   map f g @@
+   *   sequence2
+   *     (required ~label:"certId" oid)
+   *     (required ~label:"certValue" @@ explicit 0 @@
+   *        choice2 octet_string ia5_string) *)
+
+  type bag =
+    | KeyBag of Mirage_crypto_pk.Rsa.priv
+    (* | PKCS8ShroudedKeyBag of Cstruct.t (\* TODO *\) *)
+    | CertBag of Certificate.t
+
+  type t = bag * Attribute.t list
+
+  (* TODO:
+   *  -- KeyBag
+   *  KeyBag ::= PrivateKeyInfo
+   *  -- Shrouded KeyBag
+   *  PKCS8ShroudedKeyBag ::= EncryptedPrivateKeyInfo
+   *  -- CertBag
+   *  CertBag ::= SEQUENCE {
+   *      certId    BAG-TYPE.&id   ({CertTypes}),
+   *      certValue [0] EXPLICIT BAG-TYPE.&Type ({CertTypes}{@certId})
+   *  }
+   *  x509Certificate BAG-TYPE ::=
+   *      {OCTET STRING IDENTIFIED BY {certTypes 1}}
+   *      -- DER-encoded X.509 certificate stored in OCTET STRING
+   *  sdsiCertificate BAG-TYPE ::=
+   *      {IA5String IDENTIFIED BY {certTypes 2}}
+   *      -- Base64-encoded SDSI certificate stored in IA5String
+   *  CertTypes BAG-TYPE ::= {
+   *      x509Certificate |
+   *      sdsiCertificate,
+   *      ... -- For future extensions
+   *  }
+   *  -- CRLBag
+   *  -- Secret Bag *)
+
+  (* since asn1 does not yet support ANY defined BY, we develop a rather
+     complex grammar covering all supported bags
+     we are interning all types of bags into safebag structure
+     Thanks to @hannesm
+  *)
+  let safebag : t Asn.t =
+    (* let decode_cert, encode_cert = project_exn Certificate.Asn.certificate in *)
+    let encode_cert = Certificate.encode_der in
+    let decode_cert = fst (project_exn Certificate.Asn.certificate) in
+    let decode_cert cs =
+      let asn = decode_cert cs in
+      Certificate.{asn; raw = cs}
+    in
+    let f (oid, (a, algo, data)) =
+      match a, algo, data with
+      (* PrivateKeyInfo *)
+      | `C1 version, Some privateKeyAlgorithm, `C1 privateKey
+        when Asn.OID.equal oid Registry.PKCS12.keyBag ->
+        let key = Private_key.Asn.reparse_private ~sloppy:false
+            (version, privateKeyAlgorithm, privateKey) in
+        KeyBag key
+      (* CertBag *)
+      | `C2 certId, None, `C2 certValue
+        when Asn.OID.equal oid Registry.PKCS12.certBag ->
+        if Asn.OID.equal certId Registry.PKCS12.x509_certificate then
+          let cert = decode_cert certValue in
+          CertBag cert
+        else
+          parse_error "CertBag: only X509Certificate is supported"
+        (* TODO: CRLBag *)
+        (* else if Asn.OID.equal oid PKCS12.crl_bag && Asn.OID.equal id crl_oid then
+         *   match Crl.decode_der data with
+         *   | Error e -> error e
+         *   | Ok crl -> `Crl crl, attrs
+         * else
+         *   parse_error "crl bag with non-standard crl" *)
+      (* | `C3 algo, None, `C1 data when Asn.OID.equal oid PKCS12.pkcs8_shrouded_key_bag ->
+       *   `Encrypted_private_key (algo, data), attrs *)
+      | _ -> Asn.(S.parse_error "Unknown bagId %a" OID.pp oid)
+    in
+    let f (oid, value, attrs) =
+      let bag = f (oid, value) in
+      let attrs = match attrs with
+        | None -> []
+        | Some x -> x
+      in
+      bag, attrs
+    in
+    let g (bag, attrs) =
+      let attrs = Some attrs in
+      let oid, d = match bag with
+        | KeyBag pk ->
+          let v, algo, data = Private_key.Asn.unparse_private pk in
+          (* Pretending PrivateKeyInfo *)
+          Registry.PKCS12.keyBag, (
+            `C1 v, (* version *)
+            Some algo, (* privateKeyAlgorithm *)
+            `C1 data (* privateKey *)
+          )
+        (* | PKCS8ShroudedKeyBag k ->
+         *   Registry.PKCS12.pkcs8ShroudedKeyBag, `C2 k *)
+        | CertBag cert ->
+          let cert_der = encode_cert cert in
+          (* Pretending CertBag *)
+          Registry.PKCS12.certBag, (
+            `C2 Registry.PKCS12.x509_certificate, (* certId *)
+            None, (* not used *)
+            `C2 cert_der (* certValue *)
+          )
+      in
+      (oid, d, attrs)
+    in
+    map f g @@
+    sequence3
+      (required ~label:"bagId" oid)
+      (required ~label:"bagValue" @@
+       (* explicit 0 @@  choice2 pk encrypted_privatekey_info) *)
+       (explicit 0
+          (sequence3
+             (required ~label:"fst" (choice3 int oid Algorithm.identifier))
+             (optional ~label:"algorithm" Algorithm.identifier)
+             (required ~label:"data" (choice2 octet_string (explicit 0 octet_string))))))
+      (* (explicit 0 (* encrypted private key *)
+         (sequence2
+            (required ~label:"encryption algorithm" Algorithm.identifier)
+            (required ~label:"encrypted data" octet_string))) *)
+      (* (explicit 0 (* private key ] *)
+            (sequence3
+              (required ~label:"version"             int)
+              (required ~label:"privateKeyAlgorithm" Algorithm.identifier)
+              (required ~label:"privateKey"          octet_string)))  *)
+      (* (explicit 0 (* cert / crl *)
+            (sequence2
+               (required ~label:"oid" oid)
+               (required ~label:"data" (explicit 0 octet_string)))) *)
+      (optional ~label:"bagAttributes" @@ set_of Attribute.attribute)
+
+end
+
+module MacData = struct
+  open Asn.S
+  (* open Asn_grammars *)
+
+  type t = {
+    algo: Algorithm.t;
+    digest: Cstruct.t;
+    salt: Cstruct.t;
+    iterations: int;
+  }
+
+  let make ?(algo=Algorithm.SHA1) ?(iterations=2048) ?salt
+      ~password data =
+    let salt = match salt with
+      | None -> Cstruct.of_string "123456789" (* TODO *)
+      | Some x -> x
+    in
+    (* TODO *)
+    let digest = Cstruct.of_string (password ^ data) in
+    {algo;digest;salt;iterations;}
+    
+
+  let mac_data =
+    let f ((algo, digest), salt, iterations) =
+      {algo;digest;salt;iterations;}
+    in
+    let g {algo;digest;salt;iterations;} =
+      (algo, digest), salt, iterations
+    in
+    map f g @@
+    sequence3
+      (required ~label:"mac" Pkcs7.Asn.digest_info)
+      (required ~label:"macSalt" octet_string)
+      (required ~label:"iterations" int)
+end
+
+
+module Asn = struct
+  open Asn.S
+  open Asn_grammars
+
+  type safe_contents = SafeBag.t list
+  let safecontents : safe_contents t = sequence_of SafeBag.safebag
+
+  (* -- Data if unencrypted
+   * -- EncryptedData if password-encrypted
+   * -- EnvelopedData if public key-encrypted *)
+  let safecont_contentinfo =
+    let encode, decode = project_exn safecontents in
+    let f = function
+      | `Data x -> encode x
+      | `EncryptedData _ -> parse_error "TODO: safecont_contentinfo"
+      | `SignedData _ -> parse_error "TODO: safecont_contentinfo"
+    in
+    let g c =
+      (* TODO: encrypted and signed *)
+      `Data (decode c)
+    in
+    map f g @@ Pkcs7.Asn.contentinfo
+
+  type authenticated_safe = safe_contents list
+  let authenticated_safe : authenticated_safe t =
+    sequence_of safecont_contentinfo
+
+
+  (* From rfc7292:
+   * the contentType field of authSafe shall be of type data
+   * or signedData. *)
+  let authsafe_contentinfo =
+    let encode, decode = project_exn authenticated_safe in
+    let f = function
+      | `Data x -> encode x
+      | `SignedData _ -> parse_error "TODO: authsafe_contentinfo"
+      | _ -> parse_error "authSafe must contentType be either data or signedData"
+    in
+    let g c = `Data (decode c) in
+    map f g @@ Pkcs7.Asn.contentinfo
+
+  let pfx =
+    let f (_version, auth_content, mac) =
+      auth_content, mac
+    in
+    let g (auth_content, mac) =
+      3, auth_content, mac
+    in
+    map f g @@
+    sequence3
+      (required ~label:"version" int)
+      (required ~label:"authSafe" authsafe_contentinfo)
+      (optional ~label:"macData" MacData.mac_data)
+
+end

--- a/lib/pkcs7.ml
+++ b/lib/pkcs7.ml
@@ -1,0 +1,76 @@
+module Asn = struct
+  open Asn.S
+  open Asn_grammars
+
+
+  let digest_info =
+    sequence2
+      (required ~label:"digestAlgorithm" Algorithm.identifier)
+      (required ~label:"digest" octet_string)
+
+  let encrypted_content_info =
+    sequence3
+      (required ~label:"contentType" oid)
+      (required ~label:"contentEncryptionAlgorithm" Algorithm.identifier)
+      (optional ~label:"encryptedContent" @@ implicit 0 octet_string)
+
+  type encrypted_data = Asn.oid * Algorithm.t * Cstruct.t option
+
+  let encrypted_data : encrypted_data t =
+    map (fun (_, c) -> c) (fun c -> 0, c) @@
+    sequence2
+      (required ~label:"version" int)
+      (required ~label:"encryptedContentInfo" encrypted_content_info)
+
+
+  (*  SignedData ::= SEQUENCE {
+   *    version Version,
+   *    digestAlgorithms DigestAlgorithmIdentifiers,
+   *    contentInfo ContentInfo,
+   *    certificates
+   *       [0] IMPLICIT ExtendedCertificatesAndCertificates
+   *         OPTIONAL,
+   *    crls
+   *      [1] IMPLICIT CertificateRevocationLists OPTIONAL,
+   *    signerInfos SignerInfos }
+   * 
+   *  DigestAlgorithmIdentifiers ::=
+   * 
+   * SET OF DigestAlgorithmIdentifier *)
+  (* TODO *)
+  let signed_data = int
+
+
+  let contentinfo =
+    let default oid = Asn.(S.parse_error "Unknown contentType %a" OID.pp oid) in
+    let f =
+      let data = function
+        | Some (`C1 x) -> `Data x
+        | _ -> parse_error "ContentInfo: expected Data"
+      in
+      let encrypted = function
+        | Some (`C2 x) -> `EncryptedData x
+        | _ -> parse_error "ContentInfo: expected EncryptedData"
+      in
+      let signed = function
+        | Some (`C3 x) -> `SignedData x
+        | _ -> parse_error "ContentInfo: expected SignedData"
+      in
+      case_of_oid_f ~default [
+        Registry.PKCS7.data, data;
+        Registry.PKCS7.encryptedData, encrypted;
+        Registry.PKCS7.signedData, signed;
+      ]
+    in
+    let g =
+      function
+      | `Data x -> Registry.PKCS7.data, Some (`C1 x)
+      | `EncryptedData x -> Registry.PKCS7.encryptedData, Some (`C2 x)
+      | `SignedData x -> Registry.PKCS7.signedData, Some (`C3 x)
+    in
+    map f g @@
+    sequence2
+      (required ~label:"contentType" oid)
+      (optional ~label:"content" @@ explicit 0 @@
+       choice3 octet_string encrypted_data int)
+end

--- a/lib/registry.ml
+++ b/lib/registry.ml
@@ -124,6 +124,7 @@ module PKCS9 = struct
   and smime_capabilities   = pkcs9 <| 15
   and smime_oid_registry   = pkcs9 <| 16
   and friendly_name        = pkcs9 <| 20
+  and local_key_id         = pkcs9 <| 21
   and cert_types           = pkcs9 <| 22
 end
 
@@ -266,4 +267,29 @@ module Name_extn = struct
 
   let is_utf8_id oid =
     List.mem oid [ xmpp_addr ; venezuela_1 ; venezuela_2 ]
+end
+
+
+module PKCS12 = struct
+  let pkcs12 = pkcs <| 12
+
+  let pkcs_12PbeIds = pkcs12 <| 1
+  let pbeWithSHAAnd128BitRC4 = pkcs_12PbeIds <| 1
+  let pbeWithSHAAnd40BitRC4 = pkcs_12PbeIds <| 2
+  let pbeWithSHAAnd3_KeyTripleDES_CBC = pkcs_12PbeIds <| 3
+  let pbeWithSHAAnd2_KeyTripleDES_CBC = pkcs_12PbeIds <| 4
+  let pbeWithSHAAnd128BitRC2_CBC = pkcs_12PbeIds <| 5
+  let pbewithSHAAnd40BitRC2_CBC = pkcs_12PbeIds <| 6
+
+  let bagtypes = pkcs12 <| 10 <| 1
+
+  let keyBag = bagtypes <| 1
+  let pkcs8ShroudedKeyBag = bagtypes <| 2
+  let certBag = bagtypes <| 3
+  let crlBag = bagtypes <| 4
+  let secretBag = bagtypes <| 5
+  let safeContentsBag = bagtypes <| 6
+
+  let x509_certificate = PKCS9.cert_types <| 1
+  let sdsi_certificate = PKCS9.cert_types <| 2
 end

--- a/lib/x509.ml
+++ b/lib/x509.ml
@@ -19,3 +19,5 @@ module Signing_request = Signing_request
 module CRL = Crl
 
 module Authenticator = Authenticator
+
+module Pkcs12 = Pkcs12

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -890,3 +890,49 @@ module Authenticator : sig
     hash:Mirage_crypto.Hash.hash ->
     fingerprints:([`host] Domain_name.t * Cstruct.t) list -> t
 end
+
+(* TODO: *)
+(* module type of Pkcs12 *)
+module Pkcs12 : sig
+  module Attribute :
+    sig
+      type t =
+        Pkcs12.Attribute.t =
+          FriendlyName of string
+        | LocalKeyId of Cstruct.t
+      val attribute : t Asn.t
+    end
+  module SafeBag :
+    sig
+      type bag =
+        Pkcs12.SafeBag.bag =
+          KeyBag of Mirage_crypto_pk.Rsa.priv
+        | CertBag of X509__Certificate.t
+      type t = bag * Attribute.t list
+      val safebag : t Asn.t
+    end
+  module MacData :
+    sig
+      type t =
+        Pkcs12.MacData.t = {
+        algo : Algorithm.t;
+        digest : Cstruct.t;
+        salt : Cstruct.t;
+        iterations : int;
+      }
+      val make :
+        ?algo:Algorithm.t ->
+        ?iterations:int -> ?salt:Cstruct.t -> password:string -> string -> t
+      val mac_data : t Asn.t
+    end
+  module Asn :
+    sig
+      type safe_contents = SafeBag.t list
+      val safecontents : safe_contents Asn.t
+      val safecont_contentinfo : safe_contents Asn.t
+      type authenticated_safe = safe_contents list
+      val authenticated_safe : authenticated_safe Asn.t
+      val authsafe_contentinfo : authenticated_safe Asn.t
+      val pfx : (authenticated_safe * MacData.t option) Asn.t
+    end
+end

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -897,17 +897,15 @@ module Pkcs12 : sig
   module Attribute :
     sig
       type t =
-        Pkcs12.Attribute.t =
-          FriendlyName of string
+        | FriendlyName of string
         | LocalKeyId of Cstruct.t
       val attribute : t Asn.t
     end
   module SafeBag :
     sig
       type bag =
-        Pkcs12.SafeBag.bag =
           KeyBag of Mirage_crypto_pk.Rsa.priv
-        | CertBag of X509__Certificate.t
+        | CertBag of Certificate.t
       type t = bag * Attribute.t list
       val safebag : t Asn.t
     end
@@ -921,8 +919,9 @@ module Pkcs12 : sig
         iterations : int;
       }
       val make :
-        ?algo:Algorithm.t ->
-        ?iterations:int -> ?salt:Cstruct.t -> password:string -> string -> t
+        ?algo:Mirage_crypto.Hash.hash ->
+        ?iterations:int -> ?salt:Cstruct.t ->
+        password:string -> Cstruct.t -> t
       val mac_data : t Asn.t
     end
   module Asn :
@@ -931,8 +930,12 @@ module Pkcs12 : sig
       val safecontents : safe_contents Asn.t
       val safecont_contentinfo : safe_contents Asn.t
       type authenticated_safe = safe_contents list
-      val authenticated_safe : authenticated_safe Asn.t
-      val authsafe_contentinfo : authenticated_safe Asn.t
-      val pfx : (authenticated_safe * MacData.t option) Asn.t
+      (* val authenticated_safe : authenticated_safe Asn.t
+       * val authsafe_contentinfo : Cstruct.t Asn.t
+       * val pfx : (Cstruct.t * MacData.t option) Asn.t *)
     end
+
+  (** Create PFX (P12) container optionally MACed. *)
+  val pfx: ?mac_password:string ->
+    Asn.authenticated_safe -> Cstruct.t
 end

--- a/tests/pkcs12.ml
+++ b/tests/pkcs12.ml
@@ -1,0 +1,51 @@
+
+
+let test_raw_private_key () =
+  let pk = Mirage_crypto_pk.Rsa.generate ~bits:1024 () in
+  let safebag = X509.Pkcs12.SafeBag.KeyBag pk, [] in
+  let safecontents = [safebag] in
+  let autheticated_safe = [safecontents] in
+  let pfx = autheticated_safe in
+  let codec = Asn.codec Asn.ber X509.Pkcs12.Asn.pfx in
+  let pfx_ber = Asn.encode codec pfx in
+  let result = pfx_ber in
+  (* Hex.(of_cstruct result |> hexdump ~print_chars:false); *)
+  (* Hex.(to_string @@ of_cstruct result |> Base64.encode_exn |> print_endline); *)
+  Cstruct.hexdump result;
+  Cstruct.to_string result |> Base64.encode_exn |> print_endline;
+  (* let out = open_out_bin "/tmp/1.p12" in
+   * output_string out (Cstruct.to_string result);
+   * close_out out; *)
+  assert (1 = 1)
+
+
+let test_cert_and_raw_key () =
+  let pk = X509tests.priv in
+  let cert = X509tests.cacert in
+  let cert_hash = X509.Certificate.fingerprint `SHA1 cert in
+  let safebag_key = X509.Pkcs12.(SafeBag.KeyBag pk, [
+      Attribute.LocalKeyId cert_hash
+    ]) in
+  let safebag_cert = X509.Pkcs12.(SafeBag.CertBag cert, [
+      Attribute.LocalKeyId cert_hash
+    ]) in
+  let safecontents = [safebag_key; safebag_cert] in
+  let autheticated_safe = [safecontents] in
+  let pfx = autheticated_safe in
+  let codec = Asn.codec Asn.ber X509.Pkcs12.Asn.pfx in
+  let pfx_ber = Asn.encode codec pfx in
+  let result = pfx_ber in
+  (* Hex.(of_cstruct result |> hexdump ~print_chars:false); *)
+  (* Hex.(to_string @@ of_cstruct result |> Base64.encode_exn |> print_endline); *)
+  Cstruct.hexdump result;
+  Cstruct.to_string result |> Base64.encode_exn |> print_endline;
+  let out = open_out_bin "/tmp/1.p12" in
+  output_string out (Cstruct.to_string result);
+  close_out out;
+  assert (1 = 2)
+
+
+let tests = [
+  "Test raw private_key pack", `Quick, test_raw_private_key ;
+  "Test cert and raw private_key pack", `Quick, test_cert_and_raw_key ;
+]

--- a/tests/pkcs12.ml
+++ b/tests/pkcs12.ml
@@ -4,18 +4,12 @@ let test_raw_private_key () =
   let pk = Mirage_crypto_pk.Rsa.generate ~bits:1024 () in
   let safebag = X509.Pkcs12.SafeBag.KeyBag pk, [] in
   let safecontents = [safebag] in
-  let autheticated_safe = [safecontents] in
-  let pfx = autheticated_safe in
-  let codec = Asn.codec Asn.ber X509.Pkcs12.Asn.pfx in
-  let pfx_ber = Asn.encode codec pfx in
+  let pfx_ber = X509.Pkcs12.pfx [safecontents] in
   let result = pfx_ber in
   (* Hex.(of_cstruct result |> hexdump ~print_chars:false); *)
   (* Hex.(to_string @@ of_cstruct result |> Base64.encode_exn |> print_endline); *)
   Cstruct.hexdump result;
   Cstruct.to_string result |> Base64.encode_exn |> print_endline;
-  (* let out = open_out_bin "/tmp/1.p12" in
-   * output_string out (Cstruct.to_string result);
-   * close_out out; *)
   assert (1 = 1)
 
 
@@ -30,22 +24,43 @@ let test_cert_and_raw_key () =
       Attribute.LocalKeyId cert_hash
     ]) in
   let safecontents = [safebag_key; safebag_cert] in
-  let autheticated_safe = [safecontents] in
-  let pfx = autheticated_safe in
-  let codec = Asn.codec Asn.ber X509.Pkcs12.Asn.pfx in
-  let pfx_ber = Asn.encode codec pfx in
+  let pfx_ber = X509.Pkcs12.pfx [safecontents] in
   let result = pfx_ber in
   (* Hex.(of_cstruct result |> hexdump ~print_chars:false); *)
   (* Hex.(to_string @@ of_cstruct result |> Base64.encode_exn |> print_endline); *)
   Cstruct.hexdump result;
   Cstruct.to_string result |> Base64.encode_exn |> print_endline;
-  let out = open_out_bin "/tmp/1.p12" in
-  output_string out (Cstruct.to_string result);
-  close_out out;
-  assert (1 = 2)
+  (* let out = open_out_bin "/tmp/1.p12" in
+   * output_string out (Cstruct.to_string result);
+   * close_out out; *)
+  assert (1 = 1)
+
+
+let test_cert_and_raw_key_maced () =
+  let pk = X509tests.priv in
+  let cert = X509tests.cacert in
+  let cert_hash = X509.Certificate.fingerprint `SHA1 cert in
+  let safebag_key = X509.Pkcs12.(SafeBag.KeyBag pk, [
+      Attribute.LocalKeyId cert_hash
+    ]) in
+  let safebag_cert = X509.Pkcs12.(SafeBag.CertBag cert, [
+      Attribute.LocalKeyId cert_hash
+    ]) in
+  let safecontents = [safebag_key; safebag_cert] in
+  let pfx_ber = X509.Pkcs12.pfx ~mac_password:"123456" [safecontents] in
+  let result = pfx_ber in
+  (* Hex.(of_cstruct result |> hexdump ~print_chars:false); *)
+  (* Hex.(to_string @@ of_cstruct result |> Base64.encode_exn |> print_endline); *)
+  Cstruct.hexdump result;
+  Cstruct.to_string result |> Base64.encode_exn |> print_endline;
+  (* let out = open_out_bin "/tmp/1.p12" in
+   * output_string out (Cstruct.to_string result);
+   * close_out out; *)
+  assert (1 = 1)
 
 
 let tests = [
   "Test raw private_key pack", `Quick, test_raw_private_key ;
   "Test cert and raw private_key pack", `Quick, test_cert_and_raw_key ;
+  "Test cert and raw private_key_maced pack", `Quick, test_cert_and_raw_key_maced ;
 ]

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -4,6 +4,7 @@ let suites =
     "Host names", Regression.hostname_tests ;
     "Revoke", Revoke.revoke_tests ;
     "CRL", Crltests.crl_tests ;
+    "PKCS12", Pkcs12.tests ;
   ]
 
 


### PR DESCRIPTION
I wanted to implement basic use-case of pkcs12 - ability to pack cert and key encrypted with password to a pfx file. Then @hannesm showed me https://github.com/mirleft/ocaml-x509/pull/114 but it seems to be outdated. I'm not sure this PR should be merged, but may be it should be left for history purpose.