### PR TITLE
CRL: move [crls] argument in CRL.is_revoked to the last position

### DIFF
--- a/lib/crl.ml
+++ b/lib/crl.ml
@@ -173,7 +173,7 @@ let reason (revoked : revoked_cert) =
   | Some (_, x) -> Some x
   | None -> None
 
-let is_revoked (crls : t list) ?hash_whitelist ~issuer:super ~cert =
+let is_revoked ?hash_whitelist ~issuer:super ~cert (crls : t list) =
   List.exists (fun crl ->
       if
         Distinguished_name.equal (Certificate.subject super) (issuer crl)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -820,12 +820,12 @@ module CRL : sig
   val verify : t -> ?hash_whitelist:Mirage_crypto.Hash.hash list ->
     ?time:Ptime.t -> Certificate.t -> (unit, [> verification_error ]) result
 
-  (** [is_revoked crls ~hash_whitelist ~issuer ~cert] is [true] if there exists
+  (** [is_revoked ~hash_whitelist ~issuer ~cert crls] is [true] if there exists
       a revocation of [cert] in [crls] which is signed by the [issuer].  The
       subject of [issuer] must match the issuer of the crl.  The hash algorithm
       used for signing must be in the [hash_whitelist] (defaults to SHA-2).  *)
-  val is_revoked : t list -> ?hash_whitelist:Mirage_crypto.Hash.hash list ->
-    issuer:Certificate.t -> cert:Certificate.t -> bool
+  val is_revoked : ?hash_whitelist:Mirage_crypto.Hash.hash list ->
+    issuer:Certificate.t -> cert:Certificate.t -> t list -> bool
 
   (** {1 Construction and signing of CRLs} *)
 


### PR DESCRIPTION
This is to avoid warning 16 (defaults to be enabled with 4.12).