### PR TITLE
Add X509.Private_key.of_string function, as used in awa-ssh and dns-certify

### DIFF
--- a/lib/private_key.ml
+++ b/lib/private_key.ml
@@ -59,6 +59,21 @@ let of_cstruct data =
     let* k = ec_err (P521.Dsa.priv_of_cstruct data) in
     Ok (`P521 k)
 
+let of_string ?seed_or_data ?bits typ data =
+  match seed_or_data with
+  | None ->
+    begin match typ with
+      | `RSA -> Ok (generate ~seed:(Cstruct.of_string data) ?bits `RSA)
+      | _ ->
+        let* data = Base64.decode data in
+        of_cstruct (Cstruct.of_string data) typ
+    end
+  | Some `Seed ->
+    Ok (generate ~seed:(Cstruct.of_string data) ?bits typ)
+  | Some `Data ->
+    let* data = Base64.decode data in
+    of_cstruct (Cstruct.of_string data) typ
+
 let public = function
   | `RSA priv -> `RSA (Mirage_crypto_pk.Rsa.pub_of_priv priv)
   | `ED25519 priv -> `ED25519 (Mirage_crypto_ec.Ed25519.pub_of_priv priv)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -191,9 +191,17 @@ module Private_key : sig
   *)
   val generate : ?seed:Cstruct.t -> ?bits:int -> Key_type.t -> t
 
-  (** [of_cstruct data] decodes the buffer as private key. Only supported
+  (** [of_cstruct data type] decodes the buffer as private key. Only supported
       for elliptic curve keys. *)
   val of_cstruct : Cstruct.t -> Key_type.t -> (t, [> `Msg of string ]) result
+
+  (** [of_string ~seed_or_data ~bits type data] attempts to decode the data as a
+      private key. If [seed_or_data] is provided and [`Seed], the [data] is
+      taken as seed and {!generate} is used. If it is [`Data], {!of_cstruct} is
+      used with the Base64 decoded [data]. By default, if [type] is RSA, the
+      data is used as seed, otherwise directly as the private key data. *)
+  val of_string : ?seed_or_data:[`Seed | `Data] -> ?bits:int -> Key_type.t ->
+    string -> (t, [> `Msg of string ]) result
 
   (** {1 Operations on private keys} *)
 

--- a/tests/priv.ml
+++ b/tests/priv.ml
@@ -1,0 +1,41 @@
+open X509
+
+let pk_equal a b =
+  Cstruct.equal
+    (Mirage_crypto.Hash.SHA256.digest (Private_key.encode_der a))
+    (Mirage_crypto.Hash.SHA256.digest (Private_key.encode_der b))
+
+let generate_rsa () =
+  let seed = "Test1234" in
+  let pk = Private_key.generate ~seed:(Cstruct.of_string seed) `RSA in
+  let pk' = Result.get_ok (Private_key.of_string `RSA seed) in
+  let pk'' = Result.get_ok (Private_key.of_string ~seed_or_data:`Seed `RSA seed) in
+  Alcotest.(check bool "generate and of_string" true (pk_equal pk pk'));
+  Alcotest.(check bool "generate and of_string ~seed" true (pk_equal pk pk''));
+  match Private_key.of_string ~seed_or_data:`Data `RSA seed with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected failure (of_string `Data `RSA)"
+
+let b64_dec s = Base64.decode_exn s |> Cstruct.of_string
+
+let test_ec (key_type, data) () =
+  let pk = Result.get_ok (Private_key.of_cstruct (b64_dec data) key_type) in
+  let pk' = Result.get_ok (Private_key.of_string key_type data) in
+  let pk'' = Result.get_ok (Private_key.of_string ~seed_or_data:`Data key_type data) in
+  Alcotest.(check bool "generate and of_string" true (pk_equal pk pk'));
+  Alcotest.(check bool "generate and of_string ~data" true (pk_equal pk pk''));
+  match Private_key.of_string ~seed_or_data:`Seed key_type data with
+  | Error _ -> Alcotest.fail "expected ok (of_string `Seed)"
+  | Ok pk''' -> Alcotest.(check bool "generate and of_String ~seed" false (pk_equal pk pk'''))
+
+let ec_data = [
+  `ED25519, "W0p4c4tBHtSaTj4zij4oARCjhFbIi8voYg+65bl7wLU=" ;
+  `P224, "Wjy6Nf4/xJSaaR/eeoQBUxJMA3PDP/c+8VkuPA==" ;
+  `P256, "arvDmHpdTdzbc0uo+KCXoArmrmAs2GAvfk14D8gi6gM=" ;
+  `P384, "UEZz/xVx2f3s7W8/cFy/w38LkjAq0xfMYJiXamdwgW9zwSK18+vrhKzgE23sFnyq" ;
+  `P521, "AVb4DIpMO5hzyfX1n4qi4xtj/JBDCTCwyOLasKnnVS6FHW2hEZbGwd1c2J4rwpNKZqTKNsKu3dVJAmlp3EFhqv5T" ;
+]
+
+let tests =
+  ("Generate RSA", `Quick, generate_rsa) ::
+  List.map (fun d -> Key_type.to_string (fst d), `Quick, test_ec d) ec_data

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -6,6 +6,7 @@ let suites =
     "CRL", Crltests.crl_tests ;
     "PKCS12", Pkcs12.tests ;
     "OCSP", Ocsp.tests ;
+    "Private Key", Priv.tests ;
   ]
 
 


### PR DESCRIPTION
This decodes a string to a private key - depending on the key type using
either of_cstruct or generate (by default), allowing ~seed_or_data being
passed explicitly.

https://github.com/mirage/awa-ssh/pull/39
https://github.com/mirage/ocaml-dns/commit/06d878037176b24ef55264fbae2b3bceeefa9033