### PR TITLE
Add Authenticator.of_string

### DIFF
--- a/lib/authenticator.ml
+++ b/lib/authenticator.ml
@@ -54,11 +54,11 @@ let of_fingerprint str =
 
 let of_string str =
   match String.split_on_char ':' str with
-  | "key" :: tls_key_fingerprint ->
+  | "key-fp" :: tls_key_fingerprint ->
     let tls_key_fingerprint = String.concat ":" tls_key_fingerprint in
     let* hash, fingerprint = of_fingerprint tls_key_fingerprint in
     Ok (fun time -> server_key_fingerprint ~time ~hash ~fingerprint)
-  | "cert" :: tls_cert_fingerprint ->
+  | "cert-fp" :: tls_cert_fingerprint ->
     let tls_cert_fingerprint = String.concat ":" tls_cert_fingerprint in
     let* hash, fingerprint = of_fingerprint tls_cert_fingerprint in
     Ok (fun time -> server_cert_fingerprint ~time ~hash ~fingerprint)

--- a/lib/authenticator.ml
+++ b/lib/authenticator.ml
@@ -29,13 +29,11 @@ let of_fingerprint str =
       Result.map_error
         (function `Msg m ->
            `Msg (Fmt.str "Invalid base64 encoding in fingerprint (%s): %S" m s))
-        (Base64.decode s)
+        (Base64.decode ~pad:false s)
     in
     Ok (Cstruct.of_string d)
   in
   let hash_of_string = function
-    | "md5" -> Ok `MD5
-    | "sha" | "sha1" -> Ok `SHA1
     | "sha224" -> Ok `SHA224
     | "sha256" -> Ok `SHA256
     | "sha384" -> Ok `SHA384
@@ -66,7 +64,7 @@ let of_string str =
     let* anchors =
       List.fold_left (fun acc s ->
           let* acc = acc in
-          let* der = Base64.decode s in
+          let* der = Base64.decode ~pad:false s in
           let* cert = Certificate.decode_der (Cstruct.of_string der) in
           Ok (cert :: acc))
         (Ok []) certs

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1018,9 +1018,9 @@ module Authenticator : sig
   val server_cert_fingerprint : time:(unit -> Ptime.t option) ->
     hash:Mirage_crypto.Hash.hash -> fingerprint:Cstruct.t -> t
 
-  val of_string : time:(unit -> Ptime.t option) -> string
-    -> (Authenticator.t, [> `Msg of string ]) result
-  (** [of_string ~time str] tries to parse the given [str] to an
+  val of_string : string
+    -> ((unit -> Ptime.t option) -> Authenticator.t, [> `Msg of string ]) result
+  (** [of_string str] tries to parse the given [str] to an
       {!type:Authenticator.t}. The format of it is:
       - [none] no authentication
       - [key(:<hash>)?<base64-encoded fingerprint>] to authenticate a peer via
@@ -1028,7 +1028,9 @@ module Authenticator : sig
       - [cert(:<hash>)?<base64-encoded fingerprint>] to authenticate a peer via
         its certificate fingerprint
       - [trust-anchor(:<base64-encoded DER certificate>)+ to authenticate a peer from
-        a list of certificates *)
+        a list of certificates
+
+      It returns a function which expect a [now ()] function as an argument. *)
 end
 
 (** PKCS12 archive files *)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1033,8 +1033,8 @@ module Authenticator : sig
       If decoding is successful, the returned value expects a function which
       outputs the current timestamp ([unit -> Ptime.t option]) and is then
       an authenticator. If decoding fails, and error is returned. *)
-  val of_string : string
-    -> ((unit -> Ptime.t option) -> t, [> `Msg of string ]) result
+  val of_string : string ->
+    ((unit -> Ptime.t option) -> t, [> `Msg of string ]) result
 end
 
 (** PKCS12 archive files *)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1022,15 +1022,17 @@ module Authenticator : sig
     -> ((unit -> Ptime.t option) -> t, [> `Msg of string ]) result
   (** [of_string str] tries to parse the given [str] to an
       {!type:Authenticator.t}. The format of it is:
-      - [none] no authentication
-      - [key(:<hash>)?<base64-encoded fingerprint>] to authenticate a peer via
-        its key fingerprint
-      - [cert(:<hash>)?<base64-encoded fingerprint>] to authenticate a peer via
-        its certificate fingerprint
-      - [trust-anchor(:<base64-encoded DER certificate>)+] to authenticate a peer from
-        a list of certificates
+      - [none] no authentication,
+      - [key(:<hash>?):<base64-encoded fingerprint>] to authenticate a peer via
+        its key fingerprint (hash is optional and defaults to SHA256),
+      - [cert(:<hash>?):<base64-encoded fingerprint>] to authenticate a peer via
+        its certificate fingerprint (hash is optional and defaults to SHA256),
+      - [trust-anchor(:<base64-encoded DER certificate>)+] to authenticate a
+        peer from a list of certificates.
 
-      It returns a function which expect a [now ()] function as an argument. *)
+      If decoding is successful, the returned value expects a function which
+      outputs the current timestamp ([unit -> Ptime.t option]) and is then
+      an authenticator. If decoding fails, and error is returned. *)
 end
 
 (** PKCS12 archive files *)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1017,6 +1017,18 @@ module Authenticator : sig
       over certificate pinning. *)
   val server_cert_fingerprint : time:(unit -> Ptime.t option) ->
     hash:Mirage_crypto.Hash.hash -> fingerprint:Cstruct.t -> t
+
+  val of_string : time:(unit -> Ptime.t option) -> string
+    -> (Authenticator.t, [> `Msg of string ]) result
+  (** [of_string ~time str] tries to parse the given [str] to an
+      {!type:Authenticator.t}. The format of it is:
+      - [none] no authentication
+      - [key(:<hash>)?<base64-encoded fingerprint>] to authenticate a peer via
+        its key fingerprint
+      - [cert(:<hash>)?<base64-encoded fingerprint>] to authenticate a peer via
+        its certificate fingerprint
+      - [trust-anchor(:<base64-encoded DER certificate>)+ to authenticate a peer from
+        a list of certificates *)
 end
 
 (** PKCS12 archive files *)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1019,7 +1019,7 @@ module Authenticator : sig
     hash:Mirage_crypto.Hash.hash -> fingerprint:Cstruct.t -> t
 
   val of_string : string
-    -> ((unit -> Ptime.t option) -> Authenticator.t, [> `Msg of string ]) result
+    -> ((unit -> Ptime.t option) -> t, [> `Msg of string ]) result
   (** [of_string str] tries to parse the given [str] to an
       {!type:Authenticator.t}. The format of it is:
       - [none] no authentication

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1018,8 +1018,6 @@ module Authenticator : sig
   val server_cert_fingerprint : time:(unit -> Ptime.t option) ->
     hash:Mirage_crypto.Hash.hash -> fingerprint:Cstruct.t -> t
 
-  val of_string : string
-    -> ((unit -> Ptime.t option) -> t, [> `Msg of string ]) result
   (** [of_string str] tries to parse the given [str] to an
       {!type:Authenticator.t}. The format of it is:
       - [none] no authentication,
@@ -1028,11 +1026,15 @@ module Authenticator : sig
       - [cert(:<hash>?):<base64-encoded fingerprint>] to authenticate a peer via
         its certificate fingerprint (hash is optional and defaults to SHA256),
       - [trust-anchor(:<base64-encoded DER certificate>)+] to authenticate a
-        peer from a list of certificates.
+        peer from a list of certificates (certificate must be in PEM format
+        without header and footer (----BEGIN CERTIFICATE-----) and without
+        newlines).
 
       If decoding is successful, the returned value expects a function which
       outputs the current timestamp ([unit -> Ptime.t option]) and is then
       an authenticator. If decoding fails, and error is returned. *)
+  val of_string : string
+    -> ((unit -> Ptime.t option) -> t, [> `Msg of string ]) result
 end
 
 (** PKCS12 archive files *)

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1021,9 +1021,9 @@ module Authenticator : sig
   (** [of_string str] tries to parse the given [str] to an
       {!type:Authenticator.t}. The format of it is:
       - [none] no authentication,
-      - [key(:<hash>?):<base64-encoded fingerprint>] to authenticate a peer via
+      - [key-fp(:<hash>?):<base64-encoded fingerprint>] to authenticate a peer via
         its key fingerprint (hash is optional and defaults to SHA256),
-      - [cert(:<hash>?):<base64-encoded fingerprint>] to authenticate a peer via
+      - [cert-fp(:<hash>?):<base64-encoded fingerprint>] to authenticate a peer via
         its certificate fingerprint (hash is optional and defaults to SHA256),
       - [trust-anchor(:<base64-encoded DER certificate>)+] to authenticate a
         peer from a list of certificates (certificate must be in PEM format

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1027,7 +1027,7 @@ module Authenticator : sig
         its key fingerprint
       - [cert(:<hash>)?<base64-encoded fingerprint>] to authenticate a peer via
         its certificate fingerprint
-      - [trust-anchor(:<base64-encoded DER certificate>)+ to authenticate a peer from
+      - [trust-anchor(:<base64-encoded DER certificate>)+] to authenticate a peer from
         a list of certificates
 
       It returns a function which expect a [now ()] function as an argument. *)


### PR DESCRIPTION
Related to [mirage/ocaml-dns](https://github.com/mirage/ocaml-dns/pull/297#discussion_r805649032). A simple function which tries to deserialize a string to an `Authenticator.t`.