### PR TITLE
WIP: Add PKCS12 LocalKeyId attribute to bags (openssl and firefox compatibility)

### DIFF
--- a/lib/registry.ml
+++ b/lib/registry.ml
@@ -147,6 +147,7 @@ module PKCS9 = struct
   and smime_capabilities   = pkcs9 <| 15
   and smime_oid_registry   = pkcs9 <| 16
   and friendly_name        = pkcs9 <| 20
+  and local_key_id         = pkcs9 <| 21
   and cert_types           = pkcs9 <| 22
   and crl_types            = pkcs9 <| 23
 end

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1057,13 +1057,14 @@ module PKCS12 : sig
      | `Private_key of Private_key.t | `Decrypted_private_key of Private_key.t ]
        list, [> `Msg of string ]) result
 
-  (** [create ~mac ~algorithm ~iterations password certificates private_key]
+  (** [create ~mac ~algorithm ~iterations ~local_key_id password certificates private_key]
       constructs a PKCS12 archive with [certificates] and [private_key]. They
       are encrypted with [algorithm] (using PBES2, PKCS5v2) and integrity
       protected using [mac]. *)
   val create : ?mac:[`SHA1 | `SHA224 | `SHA256 | `SHA384 | `SHA512 ] ->
     ?algorithm:[ `AES128_CBC | `AES192_CBC | `AES256_CBC ] ->
     ?iterations:int ->
+    ?local_key_id:Cstruct.t ->
     string -> Certificate.t list -> Private_key.t ->
     t
 end


### PR DESCRIPTION
Hi, @hannesm! I've tried to upgrade my project to latest version of x509 lib and found that pkcs12 doesn't work for me:( 
In PR https://github.com/mirleft/ocaml-x509/pull/138 I've suggested to add attribute LocalKeyId to SafeBags because openssl adds it automatically and firefox fails to import p12 container without it. As I understand, LocalKeyId is required to map private key with certificate it corresponds to (because there may be lots of keys and certs in container).
I would like to add some unittests for it, but x509.PKCS12 module doesn't export api for accessing bags attributes.
![firefox_fails_to_import](https://github.com/mirleft/ocaml-x509/assets/1741178/b2a7fdcf-ef18-42f6-a8e8-ee0198b7c31d)
![localkeyid_in_cert](https://github.com/mirleft/ocaml-x509/assets/1741178/6e4facac-f906-43ee-b5ee-d21f44de55cd)

