### PR TITLE
Rename Authenticator.server_{cert,key}_fingerprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 * Remove P224 (@dinosaure, @hannes, #166)
 * The serial number of certificates is a `string` and enforced to be a positive
   integer of at most 20 bytes in length (@hannesm, #167)
+* **breaking change** `Authenticator.server_key_fingerprint` and
+  `Authenticator.server_cert_fingerprint` are now known as
+  `Authenticator.key_fingerprint` and `Authenticator.cert_fingerprint`
+  respectively to better reflect that they do not check extended key usage is
+  "server" and may as well be used for authenticating clients (@reynir, #164)
 
 ## v0.16.5 (2023-07-03)
 

--- a/lib/authenticator.ml
+++ b/lib/authenticator.ml
@@ -15,11 +15,11 @@ let chain_of_trust ~time ?crls ?(allowed_hashes = Validation.sha2) cas =
     Validation.verify_chain_of_trust ?ip ~host ~time ?revoked ~allowed_hashes
       ~anchors:cas certificates
 
-let server_key_fingerprint ~time ~hash ~fingerprint =
+let key_fingerprint ~time ~hash ~fingerprint =
   fun ?ip ~host certificates ->
     Validation.trust_key_fingerprint ?ip ~host ~time ~hash ~fingerprint certificates
 
-let server_cert_fingerprint ~time ~hash ~fingerprint =
+let cert_fingerprint ~time ~hash ~fingerprint =
   fun ?ip ~host certificates ->
     Validation.trust_cert_fingerprint ?ip ~host ~time ~hash ~fingerprint certificates
 

--- a/lib/authenticator.ml
+++ b/lib/authenticator.ml
@@ -57,17 +57,17 @@ let of_string str =
   | [ "key-fp" ; hash ; tls_key_fingerprint ] ->
     let* hash = hash_of_string (String.lowercase_ascii hash) in
     let* fingerprint = fingerprint_of_string tls_key_fingerprint in
-    Ok (fun time -> server_key_fingerprint ~time ~hash ~fingerprint)
+    Ok (fun time -> key_fingerprint ~time ~hash ~fingerprint)
   | [ "key-fp" ; tls_key_fingerprint ] ->
     let* fingerprint = fingerprint_of_string tls_key_fingerprint in
-    Ok (fun time -> server_key_fingerprint ~time ~hash:`SHA256 ~fingerprint)
+    Ok (fun time -> key_fingerprint ~time ~hash:`SHA256 ~fingerprint)
   | [ "cert-fp" ; hash ; tls_cert_fingerprint ] ->
     let* hash = hash_of_string (String.lowercase_ascii hash) in
     let* fingerprint = fingerprint_of_string tls_cert_fingerprint in
-    Ok (fun time -> server_cert_fingerprint ~time ~hash ~fingerprint)
+    Ok (fun time -> cert_fingerprint ~time ~hash ~fingerprint)
   | [ "cert-fp" ; tls_cert_fingerprint ] ->
     let* fingerprint = fingerprint_of_string tls_cert_fingerprint in
-    Ok (fun time -> server_cert_fingerprint ~time ~hash:`SHA256 ~fingerprint)
+    Ok (fun time -> cert_fingerprint ~time ~hash:`SHA256 ~fingerprint)
   | "trust-anchor" :: certs ->
     let* anchors =
       List.fold_left (fun acc s ->

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1000,22 +1000,22 @@ module Authenticator : sig
   val chain_of_trust : time:(unit -> Ptime.t option) -> ?crls:CRL.t list ->
     ?allowed_hashes:Digestif.hash' list -> Certificate.t list -> t
 
-  (** [server_key_fingerprint ~time hash fingerprint] is an [authenticator]
+  (** [key_fingerprint ~time hash fingerprint] is an [authenticator]
       that uses the given [time] and [fingerprint] to verify that the
       fingerprint of the first element of the certificate chain matches the
       given fingerprint, using {!Validation.trust_key_fingerprint}. *)
-  val server_key_fingerprint : time:(unit -> Ptime.t option) ->
+  val key_fingerprint : time:(unit -> Ptime.t option) ->
     hash:Digestif.hash' -> fingerprint:string -> t
 
-  (** [server_cert_fingerprint ~time hash fingerprint] is an [authenticator]
+  (** [cert_fingerprint ~time hash fingerprint] is an [authenticator]
       that uses the given [time] and [fingerprint] to verify the first
       element of the certificate chain, using
       {!Validation.trust_cert_fingerprint}.  Note that
       {{!server_key_fingerprint}public key pinning} has
       {{:https://www.imperialviolet.org/2011/05/04/pinning.html} advantages}
       over certificate pinning. *)
-  val server_cert_fingerprint : time:(unit -> Ptime.t option) ->
-    hash:Digestif.hash' -> fingerprint:string -> t
+  val cert_fingerprint : time:(unit -> Ptime.t option) ->
+    hash:Digestif.hash' -> fingerprint:Cstruct.t -> t
 
   (** [of_string str] tries to parse the given [str] to an
       {!type:Authenticator.t}. The format of it is:

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -1015,7 +1015,7 @@ module Authenticator : sig
       {{:https://www.imperialviolet.org/2011/05/04/pinning.html} advantages}
       over certificate pinning. *)
   val cert_fingerprint : time:(unit -> Ptime.t option) ->
-    hash:Digestif.hash' -> fingerprint:Cstruct.t -> t
+    hash:Digestif.hash' -> fingerprint:string -> t
 
   (** [of_string str] tries to parse the given [str] to an
       {!type:Authenticator.t}. The format of it is:


### PR DESCRIPTION
By dropping the server_ prefix. The functions do not check that the certificate have extended key usage of server auth and could just as well be used to authenticate clients (although the server case is more likely). The old names are kept as aliases and a deprecation attribute is added.

This may result in some churn, but judging from sherlocode it doesn't look *too* bad.