### PR TITLE
Fix mixup of subject and hash in error message

### DIFF
--- a/lib/validation.ml
+++ b/lib/validation.ml
@@ -24,7 +24,7 @@ let pp_signature_error ppf = function
       Distinguished_name.pp subj err Cstruct.hexdump_pp sig_
   | `Hash_not_allowed (subj, hash) ->
     Fmt.pf ppf "hash algorithm %a is not allowed, but %a is signed using it"
-      Distinguished_name.pp subj Certificate.pp_hash hash
+      Certificate.pp_hash hash Distinguished_name.pp subj
   | `Unsupported_keytype (subj, pk) ->
     Fmt.pf ppf "unsupported key used to sign %a: %a" Distinguished_name.pp subj
       Public_key.pp pk


### PR DESCRIPTION
`hash algorithm /CN=snakeoil is not allowed, but SHA224 is signed using it` is a funny but confusing error message :D