### PR TITLE
Add Certificate.fold_decode_pem_multiple

### DIFF
--- a/lib/certificate.ml
+++ b/lib/certificate.ml
@@ -146,6 +146,18 @@ let decode_pem_multiple cs =
   in
   Pem.foldM (fun (_, cs) -> decode_der cs) certs
 
+let fold_decode_pem_multiple fn acc cs =
+  List.fold_left
+    (fun acc data ->
+      let data = match data with
+        | Ok ("CERTIFICATE", cs) -> decode_der cs
+        | Ok _ -> Error (`Msg "ignore non certificate")
+        | Error e -> Error e
+      in
+      fn acc data)
+    acc
+    (Pem.parse_with_errors cs)
+
 let decode_pem cs =
   let* certs = decode_pem_multiple cs in
   Pem.exactly_one ~what:"certificate" certs

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -504,6 +504,11 @@ module Certificate : sig
        are extracted *)
   val decode_pem_multiple : string -> (t list, [> `Msg of string ]) result
 
+  (** [fold_decode_pem_multiple fn acc pem] is a fold of the function [fn],
+      with the initial accumulator [acc], over the certificates extracted
+      (and potential parsing errors) from the [pem]. *)
+  val fold_decode_pem_multiple : ('a -> (t, [> `Msg of string ]) result -> 'a) -> 'a -> string -> 'a
+
   (** [decode_pem pem] is [t], where the single certificate of the
       [pem] is extracted *)
   val decode_pem : string -> (t, [> `Msg of string ]) result


### PR DESCRIPTION
Following https://github.com/mirage/ca-certs/pull/30, @hannesm suggested that the handling of certificate parse errors from `pem` would be better handled in X509 than in `ca-certs`, as the parsing logic there is less complete than in X509, with no support for `\r\n` for example, but there's a need to ignore parse errors which wasn't possible before with x509 api alone.