### PR TITLE
Add alternate algorithm OID 1.3.14.3.2.29 for SHA1 with RSA encryption.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v1.0.4
+
+* Recognize 1.3.14.3.2.29 OID for SHA1 with RSA encryption (@mefyl #176)
+
 ## v1.0.3 (2024-09-04)
 
 * Use the opam package kdf instead of pbkdf (@hannesm #174)

--- a/lib/algorithm.ml
+++ b/lib/algorithm.ml
@@ -267,6 +267,7 @@ let identifier =
       (PKCS1.md5_rsa_encryption      , null_or_none MD5_RSA      ) ;
       (PKCS1.ripemd160_rsa_encryption, null_or_none RIPEMD160_RSA) ;
       (PKCS1.sha1_rsa_encryption     , null_or_none SHA1_RSA     ) ;
+      (sha1_rsa_encryption           , null_or_none SHA1_RSA     ) ;
       (PKCS1.sha256_rsa_encryption   , null_or_none SHA256_RSA   ) ;
       (PKCS1.sha384_rsa_encryption   , null_or_none SHA384_RSA   ) ;
       (PKCS1.sha512_rsa_encryption   , null_or_none SHA512_RSA   ) ;

--- a/lib/registry.ml
+++ b/lib/registry.ml
@@ -24,6 +24,7 @@ let md2  = rsadsi <| 2 <| 2
 and md4  = rsadsi <| 2 <| 4
 and md5  = rsadsi <| 2 <| 5
 and sha1 = base 1 3 <| 14 <| 3 <| 2 <| 26
+and sha1_rsa_encryption = base 1 3 <| 14 <| 3 <| 2 <| 29
 
 (* rfc5758 *)
 


### PR DESCRIPTION
Some of our user are being hit by "Unknown algorithm 1.3.14.3.2.29". After some digging around, it seems to be an alternate oid for sha1+rsa, see https://oid-rep.orange-labs.fr/get/1.3.14.3.2.29.

I have very limited knowledge of how algorithm numbers are nested/organized, so my naming probably bad, any suggestion welcome.