### PR TITLE
Generic ECDSA implementation

### DIFF
--- a/lib/algorithm.ml
+++ b/lib/algorithm.ml
@@ -11,20 +11,14 @@ open Asn_grammars
  * that handles unsupported algos anyway.
  *)
 
-type ec_curve =
-  [ `SECP256R1 | `SECP384R1 | `SECP521R1 ]
-
-let ec_curve_to_string = function
-  | `SECP256R1 -> "SECP256R1"
-  | `SECP384R1 -> "SECP384R1"
-  | `SECP521R1 -> "SECP521R1"
+let ec_curve_to_string = Dsa_curves.get_name
 
 type t =
 
   (* pk algos *)
   (* any more? is the universe big enough? ramsey's theorem for pk cyphers? *)
   | RSA
-  | EC_pub of ec_curve
+  | EC_pub of Dsa_curves.t
 
   (* sig algos *)
   | MD5_RSA
@@ -198,18 +192,12 @@ and of_signature_algorithm public_key_algorithm digest =
    Section 2.3.1 specifies rsaEncryption (for RSA public keys) requires null.
 *)
 
-let curve_of_oid, curve_to_oid =
-  let open Registry.ANSI_X9_62 in
-  (let default oid = Asn.(S.parse_error "Unknown algorithm %a" OID.pp oid) in
-   case_of_oid ~default [
-     (secp256r1, `SECP256R1) ;
-     (secp384r1, `SECP384R1) ;
-     (secp521r1, `SECP521R1) ;
-   ]),
-  (function
-    | `SECP256R1 -> secp256r1
-    | `SECP384R1 -> secp384r1
-    | `SECP521R1 -> secp521r1)
+let curve_of_oid oid =
+  match Dsa_curves.find oid with
+  | Some c -> c
+  | None -> Asn.(S.parse_error "Unknown algorithm with OID %a" OID.pp oid)
+
+let curve_to_oid = Dsa_curves.get_oid
 
 let identifier =
   let open Registry in
@@ -239,7 +227,7 @@ let identifier =
     and octets f = function
       | Some (`C4 salt) -> f salt
       | _               -> parse_error "Algorithm: expected parameter octet_string"
-    and default oid = Asn.(S.parse_error "Unknown algorithm %a" OID.pp oid)
+    and default oid = Asn.(S.parse_error "Unknown algorithm with OID %a" OID.pp oid)
     in
 
     case_of_oid_f ~default [

--- a/lib/dsa_curves.ml
+++ b/lib/dsa_curves.ml
@@ -1,0 +1,51 @@
+module type Dsa = Mirage_crypto_ec.Dsa
+
+module OIDs = Registry.ANSI_X9_62
+
+module type S = sig
+  val name : string
+  val oid : Asn.oid
+  module Dsa : Dsa
+end
+
+type t = (module S)
+
+let curves, add_curve =
+  let curves = ref [] in
+  (fun () -> !curves),
+  (fun c -> curves := c :: !curves)
+
+let register name oid (module Dsa:Dsa) =
+  let c = (module struct
+    let name = String.lowercase_ascii name
+    let oid = oid
+    module Dsa = Dsa
+  end : S) in
+  add_curve c;
+  c
+
+let strings () =
+  List.map (fun (module C : S) ->
+    (C.name, `ECDSA (module C : S)))
+    (curves ())
+
+let find oid : t option =
+  List.find_opt (fun (module C : S) -> C.oid = oid) (curves ())
+
+let get_dsa c =
+  let (module C : S) = c in
+  (module C.Dsa : Dsa)
+
+let get_name c =
+  let (module C : S) = c in
+  C.name
+
+let get_oid c =
+  let (module C : S) = c in
+  C.oid
+
+let of_name name =
+  List.find_opt (fun (module C : S) -> C.name = name) (curves ())
+
+let names () =
+  List.map (fun (module C : S) -> C.name) (curves ())

--- a/lib/key_type.ml
+++ b/lib/key_type.ml
@@ -1,17 +1,22 @@
-type t = [ `RSA | `ED25519 | `P256 | `P384 | `P521  ]
+type t = [ `RSA | `ED25519 | `ECDSA of Dsa_curves.t]
 
-let strings =
-  [ ("rsa", `RSA) ; ("ed25519", `ED25519) ;
-    ("p256", `P256) ; ("p384", `P384) ; ("p521", `P521) ]
+let strings () =
+  ("rsa", `RSA) :: ("ed25519", `ED25519) :: (Dsa_curves.strings ())
 
-let to_string kt = fst (List.find (fun (_, k) -> kt = k) strings)
+let to_string = function
+  | `RSA -> "rsa"
+  | `ED25519 -> "ed25519"
+  | `ECDSA c -> Dsa_curves.get_name c
 
 let of_string s =
-  match List.assoc_opt (String.lowercase_ascii s) strings with
-  | Some kt -> Ok kt
-  | None ->
-    Error (`Msg (Fmt.str "unkown key type %s, supported are %a"
-                   s Fmt.(list ~sep:(any ", ") string) (List.map fst strings)))
+  match String.lowercase_ascii s with
+  | "rsa" -> Ok `RSA
+  | "ed25519" -> Ok `ED25519
+  | s -> match Dsa_curves.of_name s with
+    | Some c -> Ok (`ECDSA c)
+    | None ->
+      Error (`Msg (Fmt.str "unkown key type %s, supported are %a"
+        s Fmt.(list ~sep:(any ", ") string) (List.map fst (strings ()))))
 
 let pp ppf t = Fmt.string ppf (to_string t)
 
@@ -29,7 +34,7 @@ let supports_signature_scheme key_typ scheme =
   match key_typ, scheme with
   | `RSA, (`RSA_PSS | `RSA_PKCS1) -> true
   | `ED25519, `ED25519 -> true
-  | (`P256 | `P384 | `P521), `ECDSA -> true
+  | `ECDSA _, `ECDSA -> true
   | _ -> false
 
 let opt_signature_scheme ?scheme kt =
@@ -38,7 +43,7 @@ let opt_signature_scheme ?scheme kt =
   | None -> match kt with
     | `RSA -> `RSA_PSS
     | `ED25519 -> `ED25519
-    | `P256 | `P384 | `P521 -> `ECDSA
+    | `ECDSA _ -> `ECDSA
 
 (* the default of RSA keys should be PSS, but most deployed certificates still
    use PKCS1 (and this library uses pkcs1 by default as well) *)

--- a/lib/private_key.ml
+++ b/lib/private_key.ml
@@ -1,23 +1,22 @@
 let ( let* ) = Result.bind
 
-type ecdsa = [
-  | `P256 of Mirage_crypto_ec.P256.Dsa.priv
-  | `P384 of Mirage_crypto_ec.P384.Dsa.priv
-  | `P521 of Mirage_crypto_ec.P521.Dsa.priv
-]
+type ecdsa = Ecdsa : {
+  curve : (module Dsa_curves.S with type Dsa.priv = 'priv);
+  priv : 'priv
+} -> ecdsa
 
 type t = [
-  ecdsa
   | `RSA of Mirage_crypto_pk.Rsa.priv
   | `ED25519 of Mirage_crypto_ec.Ed25519.priv
+  | `ECDSA of ecdsa
 ]
 
 let key_type = function
   | `RSA _ -> `RSA
   | `ED25519 _ -> `ED25519
-  | `P256 _ -> `P256
-  | `P384 _ -> `P384
-  | `P521 _ -> `P521
+  | `ECDSA Ecdsa k ->
+    let (module C) = k.curve in
+    `ECDSA ((module C) : Dsa_curves.t)
 
 let generate ?seed ?(bits = 4096) typ =
   let g = match seed with
@@ -27,9 +26,12 @@ let generate ?seed ?(bits = 4096) typ =
   match typ with
   | `RSA -> `RSA (Mirage_crypto_pk.Rsa.generate ?g ~bits ())
   | `ED25519 -> `ED25519 (fst (Mirage_crypto_ec.Ed25519.generate ?g ()))
-  | `P256 -> `P256 (fst (Mirage_crypto_ec.P256.Dsa.generate ?g ()))
-  | `P384 -> `P384 (fst (Mirage_crypto_ec.P384.Dsa.generate ?g ()))
-  | `P521 -> `P521 (fst (Mirage_crypto_ec.P521.Dsa.generate ?g ()))
+  | `ECDSA (module C : Dsa_curves.S) ->
+    let priv = Ecdsa {
+      curve = (module C);
+      priv = (fst (C.Dsa.generate ?g ()))
+     } in
+    `ECDSA priv
 
 let of_octets data =
   let open Mirage_crypto_ec in
@@ -43,15 +45,13 @@ let of_octets data =
   | `ED25519 ->
     let* k = ec_err (Ed25519.priv_of_octets data) in
     Ok (`ED25519 k)
-  | `P256 ->
-    let* k = ec_err (P256.Dsa.priv_of_octets data) in
-    Ok (`P256 k)
-  | `P384 ->
-    let* k = ec_err (P384.Dsa.priv_of_octets data) in
-    Ok (`P384 k)
-  | `P521 ->
-    let* k = ec_err (P521.Dsa.priv_of_octets data) in
-    Ok (`P521 k)
+  | `ECDSA (module C : Dsa_curves.S) ->
+    let* k = ec_err (C.Dsa.priv_of_octets data) in
+    let priv = Ecdsa {
+      curve = (module C);
+      priv = k
+    } in
+    Ok (`ECDSA priv)
 
 let of_string ?seed_or_data ?bits typ data =
   match seed_or_data with
@@ -71,9 +71,13 @@ let of_string ?seed_or_data ?bits typ data =
 let public = function
   | `RSA priv -> `RSA (Mirage_crypto_pk.Rsa.pub_of_priv priv)
   | `ED25519 priv -> `ED25519 (Mirage_crypto_ec.Ed25519.pub_of_priv priv)
-  | `P256 priv -> `P256 (Mirage_crypto_ec.P256.Dsa.pub_of_priv priv)
-  | `P384 priv -> `P384 (Mirage_crypto_ec.P384.Dsa.pub_of_priv priv)
-  | `P521 priv -> `P521 (Mirage_crypto_ec.P521.Dsa.pub_of_priv priv)
+  | `ECDSA Ecdsa k  ->
+    let (module Curve) = k.curve in
+    let pub = Public_key.Ecdsa {
+      curve = (module Curve);
+      pub = Curve.Dsa.pub_of_priv k.priv
+     } in
+    `ECDSA pub
 
 let sign hash ?scheme key data =
   let open Mirage_crypto_ec in
@@ -96,12 +100,11 @@ let sign hash ?scheme key data =
         | `Message m -> Ok (Ed25519.sign ~key m)
         | `Digest _ -> Error (`Msg "Ed25519 only suitable with raw message")
       end
-    | #ecdsa as key, `ECDSA ->
+    | `ECDSA (Ecdsa k), `ECDSA ->
       let* d = hashed () in
-      Ok (ecdsa_to_str (match key with
-          | `P256 key -> P256.Dsa.(sign ~key (Public_key.trunc byte_length d))
-          | `P384 key -> P384.Dsa.(sign ~key (Public_key.trunc byte_length d))
-          | `P521 key -> P521.Dsa.(sign ~key (Public_key.trunc byte_length d))))
+      let (module Curve) = k.curve in
+      let key = k.priv in
+      Ok (ecdsa_to_str (Curve.Dsa.(sign ~key (Public_key.trunc byte_length d))))
     | _ -> Error (`Msg "invalid key and signature scheme combination")
   with
   | Mirage_crypto_pk.Rsa.Insufficient_key ->
@@ -187,12 +190,14 @@ module Asn = struct
   let ec_of_str, ec_to_str =
     Asn_grammars.project_exn ec_private_key
 
-  let reparse_ec_private curve priv =
-    let open Mirage_crypto_ec in
-    match curve with
-    | `SECP256R1 -> let* p = P256.Dsa.priv_of_octets priv in Ok (`P256 p)
-    | `SECP384R1 -> let* p = P384.Dsa.priv_of_octets priv in Ok (`P384 p)
-    | `SECP521R1 -> let* p = P521.Dsa.priv_of_octets priv in Ok (`P521 p)
+  let reparse_ec_private (curve : Dsa_curves.t) priv =
+    let (module Curve) = curve in
+    let* p = Curve.Dsa.priv_of_octets priv in
+    let k = Ecdsa {
+      curve = (module Curve);
+      priv = p
+     } in
+    Ok (`ECDSA k)
 
   (* external use (result) *)
   let ec_priv_of_str =
@@ -235,9 +240,9 @@ module Asn = struct
       match p with
       | `RSA pk -> RSA, rsa_priv_to_str pk
       | `ED25519 pk -> ED25519, ed25519_to_str (Ed25519.priv_to_octets pk)
-      | `P256 pk -> EC_pub `SECP256R1, ec_to_str (P256.Dsa.priv_to_octets pk)
-      | `P384 pk -> EC_pub `SECP384R1, ec_to_str (P384.Dsa.priv_to_octets pk)
-      | `P521 pk -> EC_pub `SECP521R1, ec_to_str (P521.Dsa.priv_to_octets pk)
+      | `ECDSA Ecdsa k ->
+        let (module Curve) = k.curve in
+        EC_pub (module Curve), ec_to_str (Curve.Dsa.priv_to_octets k.priv)
     in
     (0, alg, cs)
 

--- a/lib/public_key.ml
+++ b/lib/public_key.ml
@@ -1,15 +1,14 @@
 let ( let* ) = Result.bind
 
-type ecdsa = [
-  | `P256 of Mirage_crypto_ec.P256.Dsa.pub
-  | `P384 of Mirage_crypto_ec.P384.Dsa.pub
-  | `P521 of Mirage_crypto_ec.P521.Dsa.pub
-]
+type ecdsa = Ecdsa : {
+  curve : (module Dsa_curves.S with type Dsa.pub = 'pub);
+  pub : 'pub
+} -> ecdsa
 
 type t = [
-  | ecdsa
   | `RSA of Mirage_crypto_pk.Rsa.pub
   | `ED25519 of Mirage_crypto_ec.Ed25519.pub
+  | `ECDSA of ecdsa
 ]
 
 module Asn_oid = Asn.OID
@@ -49,9 +48,12 @@ module Asn = struct
     function
     | (RSA      , cs) -> `RSA (rsa_pub_of_octets cs)
     | (ED25519  , cs) -> `ED25519 (to_err (Ed25519.pub_of_octets cs))
-    | (EC_pub `SECP256R1, cs) -> `P256 (to_err (P256.Dsa.pub_of_octets cs))
-    | (EC_pub `SECP384R1, cs) -> `P384 (to_err (P384.Dsa.pub_of_octets cs))
-    | (EC_pub `SECP521R1, cs) -> `P521 (to_err (P521.Dsa.pub_of_octets cs))
+    | (EC_pub (module Curve), cs) ->
+      let pub = Ecdsa {
+        curve = (module Curve);
+        pub = to_err (Curve.Dsa.pub_of_octets cs)
+       } in
+      `ECDSA pub
     | _ -> parse_error "unknown public key algorithm"
 
   let unparse_pk =
@@ -60,9 +62,9 @@ module Asn = struct
     function
     | `RSA pk    -> (RSA, rsa_pub_to_octets pk)
     | `ED25519 pk -> (ED25519, Ed25519.pub_to_octets pk)
-    | `P256 pk -> (EC_pub `SECP256R1, P256.Dsa.pub_to_octets pk)
-    | `P384 pk -> (EC_pub `SECP384R1, P384.Dsa.pub_to_octets pk)
-    | `P521 pk -> (EC_pub `SECP521R1, P521.Dsa.pub_to_octets pk)
+    | `ECDSA (Ecdsa k) ->
+      let (module Curve) = k.curve in
+      (EC_pub (module Curve), Curve.Dsa.pub_to_octets k.pub)
 
   let pk_info_der =
     map reparse_pk unparse_pk @@
@@ -78,9 +80,9 @@ let id k =
   let data = match k with
     | `RSA p -> Asn.rsa_public_to_octets p
     | `ED25519 pk -> Mirage_crypto_ec.Ed25519.pub_to_octets pk
-    | `P256 pk -> Mirage_crypto_ec.P256.Dsa.pub_to_octets pk
-    | `P384 pk -> Mirage_crypto_ec.P384.Dsa.pub_to_octets pk
-    | `P521 pk -> Mirage_crypto_ec.P521.Dsa.pub_to_octets pk
+    | `ECDSA Ecdsa k ->
+      let (module Curve) = k.curve in
+      Curve.Dsa.pub_to_octets k.pub
   in
   Digestif.(to_raw_string SHA1 (digest_string SHA1 data))
 
@@ -91,12 +93,12 @@ let fingerprint ?(hash = `SHA256) pub =
 let key_type = function
   | `RSA _ -> `RSA
   | `ED25519 _ -> `ED25519
-  | `P256 _ -> `P256
-  | `P384 _ -> `P384
-  | `P521 _ -> `P521
+  | `ECDSA Ecdsa k ->
+    let (module C) = k.curve in
+    `ECDSA ((module C) : Dsa_curves.t)
 
 let sig_alg = function
-  | #ecdsa -> `ECDSA
+  | `ECDSA _ -> `ECDSA
   | `RSA _ -> `RSA
   | `ED25519 _ -> `ED25519
 
@@ -142,14 +144,12 @@ let verify hash ?scheme ~signature key data =
       | `Message msg -> ok_if_true (Ed25519.verify ~key signature ~msg)
       | `Digest _ -> Error (`Msg "Ed25519 only suitable with raw message")
     end
-  | #ecdsa as key, `ECDSA ->
+  | `ECDSA Ecdsa k, `ECDSA ->
     let* d = hashed hash data in
     let* s = ecdsa_of_str signature in
-    ok_if_true
-      (match key with
-       | `P256 key -> P256.Dsa.verify ~key s (trunc P256.Dsa.byte_length d)
-       | `P384 key -> P384.Dsa.verify ~key s (trunc P384.Dsa.byte_length d)
-       | `P521 key -> P521.Dsa.verify ~key s (trunc P521.Dsa.byte_length d))
+    let (module Curve) = k.curve in
+    let key = k.pub in
+    ok_if_true Curve.Dsa.(verify ~key s (trunc byte_length d))
   | _ -> Error (`Msg "invalid key and signature scheme combination")
 
 let encode_der = Asn.pub_info_to_octets

--- a/lib/registry.ml
+++ b/lib/registry.ml
@@ -59,6 +59,28 @@ module ANSI_X9_62 = struct
   let secp256r1 = curves <| 7
   let secp384r1 = certicom <| 34
   let secp521r1 = certicom <| 35
+
+  (* secp256k1 from SEC 2 *)
+  let secp256k1 = certicom <| 10
+
+  (* Brainpool curves from RFC 5639 *)
+  let teletrust = base 1 3 <| 36
+  let brainpool_base = teletrust <| 3 <| 3 <| 2 <| 8 <| 1 <| 1
+
+  let brainpoolP160r1 = brainpool_base <| 1
+  let brainpoolP160t1 = brainpool_base <| 2
+  let brainpoolP192r1 = brainpool_base <| 3
+  let brainpoolP192t1 = brainpool_base <| 4
+  let brainpoolP224r1 = brainpool_base <| 5
+  let brainpoolP224t1 = brainpool_base <| 6
+  let brainpoolP256r1 = brainpool_base <| 7
+  let brainpoolP256t1 = brainpool_base <| 8
+  let brainpoolP320r1 = brainpool_base <| 9
+  let brainpoolP320t1 = brainpool_base <| 10
+  let brainpoolP384r1 = brainpool_base <| 11
+  let brainpoolP384t1 = brainpool_base <| 12
+  let brainpoolP512r1 = brainpool_base <| 13
+  let brainpoolP512t1 = brainpool_base <| 14
 end
 
 module PKCS1 = struct

--- a/lib/signing_request.ml
+++ b/lib/signing_request.ml
@@ -164,9 +164,12 @@ let encode_pem v =
 let digest_of_key = function
   | `RSA _ -> `SHA256
   | `ED25519 _ -> `SHA512
-  | `P256 _ -> `SHA256
-  | `P384 _ -> `SHA384
-  | `P521 _ -> `SHA512
+  | `ECDSA Private_key.(Ecdsa k) ->
+    let (module Curve) = k.curve in
+    let l = Curve.Dsa.bit_length in
+    if l < 384 then `SHA256
+    else if l < 512 then `SHA384
+    else `SHA512
 
 let default_digest digest key =
   match digest with None -> digest_of_key key | Some x -> x

--- a/lib/x509.ml
+++ b/lib/x509.ml
@@ -1,5 +1,7 @@
 module Host = Host
 
+module Dsa_curves = Dsa_curves
+
 module Key_type = Key_type
 
 module Public_key = Public_key

--- a/lib/x509.mli
+++ b/lib/x509.mli
@@ -69,12 +69,45 @@ module Host : sig
   end
 end
 
+module Dsa_curves : sig
+  module type Dsa = Mirage_crypto_ec.Dsa
+  module type S = Dsa_curves.S
+
+  type t = (module S)
+
+  module OIDs : sig
+    val secp224r1 : Asn.oid
+    val secp256r1 : Asn.oid
+    val secp384r1 : Asn.oid
+    val secp521r1 : Asn.oid
+    val secp256k1 : Asn.oid
+    val brainpoolP160r1 : Asn.oid
+    val brainpoolP160t1 : Asn.oid
+    val brainpoolP192r1 : Asn.oid
+    val brainpoolP192t1 : Asn.oid
+    val brainpoolP224r1 : Asn.oid
+    val brainpoolP224t1 : Asn.oid
+    val brainpoolP256r1 : Asn.oid
+    val brainpoolP256t1 : Asn.oid
+    val brainpoolP320r1 : Asn.oid
+    val brainpoolP320t1 : Asn.oid
+    val brainpoolP384r1 : Asn.oid
+    val brainpoolP384t1 : Asn.oid
+    val brainpoolP512r1 : Asn.oid
+    val brainpoolP512t1 : Asn.oid
+  end
+
+  val register :
+    string -> Asn.oid -> (module Dsa) -> t
+
+end
+
 (** Types of keys *)
 module Key_type : sig
   (** The polymorphic variant of key types. *)
-  type t = [ `RSA | `ED25519 | `P256 | `P384 | `P521 ]
+  type t = [ `RSA | `ED25519 | `ECDSA of Dsa_curves.t]
 
-  val strings : (string * t) list
+  val strings : unit -> (string * t) list
   (** [strings] is an associative list of string and key_type pairs. Useful for
       {{:https://erratique.ch/software/cmdliner}cmdliner} (Arg.enum). *)
 
@@ -106,15 +139,18 @@ module Public_key : sig
 
   (** {1 The type for public keys} *)
 
+  type ecdsa = Ecdsa : {
+    curve : (module Dsa_curves.S with type Dsa.pub = 'pub);
+    pub : 'pub
+  } -> ecdsa
+
   (** The polymorphic variant of public keys, with
       {{:http://tools.ietf.org/html/rfc5208}PKCS 8} encoding and decoding to
       PEM. *)
   type t = [
     | `RSA of Mirage_crypto_pk.Rsa.pub
     | `ED25519 of Mirage_crypto_ec.Ed25519.pub
-    | `P256 of Mirage_crypto_ec.P256.Dsa.pub
-    | `P384 of Mirage_crypto_ec.P384.Dsa.pub
-    | `P521 of Mirage_crypto_ec.P521.Dsa.pub
+    | `ECDSA of ecdsa
   ]
 
   (** {1 Operations on public keys} *)
@@ -172,13 +208,16 @@ module Private_key : sig
 
   (** {1 The type for private keys} *)
 
+  type ecdsa = Ecdsa : {
+    curve : (module Dsa_curves.S with type Dsa.priv = 'priv);
+    priv : 'priv
+  } -> ecdsa
+
   (** The polymorphic variant of private keys. *)
   type t = [
     | `RSA of Mirage_crypto_pk.Rsa.priv
     | `ED25519 of Mirage_crypto_ec.Ed25519.priv
-    | `P256 of Mirage_crypto_ec.P256.Dsa.priv
-    | `P384 of Mirage_crypto_ec.P384.Dsa.priv
-    | `P521 of Mirage_crypto_ec.P521.Dsa.priv
+    | `ECDSA of ecdsa
   ]
 
   (** {1 Constructing private keys} *)

--- a/tests/custom_pp/custom_pp.ml
+++ b/tests/custom_pp/custom_pp.ml
@@ -44,6 +44,8 @@ let custom_pp ppf (oid, data) =
   else
     Fmt.pf ppf "unsupported %a: %a" Asn.OID.pp oid (Ohex.pp_hexdump ()) data
 
+let _ = X509.(Dsa_curves.register "p256" Dsa_curves.OIDs.secp256r1 (module Mirage_crypto_ec.P256.Dsa))
+
 let () =
   let fullpath = "../testcertificates/fido.pem" in
   let fd = open_in fullpath in

--- a/tests/ocsp.ml
+++ b/tests/ocsp.ml
@@ -39,6 +39,8 @@ let mmap file =
 
 let data file = mmap ("./ocsp/" ^ file)
 
+let _ = Dsa_curves.register "p521" Dsa_curves.OIDs.secp521r1 (module Mirage_crypto_ec.P521.Dsa)
+
 let responder_cert = match Certificate.decode_pem (data "certificate.pem") with
   | Ok c -> c
   | Error _ -> assert false

--- a/tests/pkcs12.ml
+++ b/tests/pkcs12.ml
@@ -23,7 +23,9 @@ let pass = "1234"
 let cert_and_key xs =
   match xs with
   | [ `Certificate c ; `Decrypted_private_key k ] ->
-    Alcotest.(check bool __LOC__ true (c = cert && k = key))
+    let a = Certificate.encode_der c = Certificate.encode_der cert in
+    let b = Private_key.encode_der k = Private_key.encode_der key in
+    Alcotest.(check bool __LOC__ true (a && b))
   | _ -> Alcotest.fail "expected certificate and key"
 
 let openssl1 () =

--- a/tests/priv.ml
+++ b/tests/priv.ml
@@ -28,11 +28,40 @@ let test_ec (key_type, data) () =
   | Error _ -> Alcotest.fail "expected ok (of_string `Seed)"
   | Ok pk''' -> Alcotest.(check bool "generate and of_String ~seed" false (pk_equal pk pk'''))
 
+
+let _compile_test =
+  (* make sure Dsa module can be used directly *)
+  let _f (pk : Private_key.t) =
+    match pk with
+    | `ECDSA Ecdsa k ->
+      let (module C) = k.curve in
+      let key = k.priv in
+      C.Dsa.sign ~key "foo"
+    | _ -> "", "";
+  in
+  let _f (pk : Public_key.t) =
+  match pk with
+  | `ECDSA Ecdsa k ->
+    let (module C) = k.curve in
+    let key = k.pub in
+    C.Dsa.verify ~key ("foo", "bar") "xyz"
+  | _ -> true; in
+ ()
+
+let p256 = Dsa_curves.register "p256" Dsa_curves.OIDs.secp256r1 (module Mirage_crypto_ec.P256.Dsa)
+let p384 = Dsa_curves.register "p384" Dsa_curves.OIDs.secp384r1 (module Mirage_crypto_ec.P384.Dsa)
+let p521 = Dsa_curves.register "p521" Dsa_curves.OIDs.secp521r1 (module Mirage_crypto_ec.P521.Dsa)
+
+
 let ec_data = [
   `ED25519, "W0p4c4tBHtSaTj4zij4oARCjhFbIi8voYg+65bl7wLU=" ;
-  `P256, "arvDmHpdTdzbc0uo+KCXoArmrmAs2GAvfk14D8gi6gM=" ;
-  `P384, "UEZz/xVx2f3s7W8/cFy/w38LkjAq0xfMYJiXamdwgW9zwSK18+vrhKzgE23sFnyq" ;
-  `P521, "AVb4DIpMO5hzyfX1n4qi4xtj/JBDCTCwyOLasKnnVS6FHW2hEZbGwd1c2J4rwpNKZqTKNsKu3dVJAmlp3EFhqv5T" ;
+  (`ECDSA p256), "arvDmHpdTdzbc0uo+KCXoArmrmAs2GAvfk14D8gi6gM=" ;
+  (`ECDSA p384), "UEZz/xVx2f3s7W8/cFy/w38LkjAq0xfMYJiXamdwgW9zwSK18+vrhKzgE23sFnyq" ;
+  (`ECDSA p521), "AVb4DIpMO5hzyfX1n4qi4xtj/JBDCTCwyOLasKnnVS6FHW2hEZbGwd1c2J4rwpNKZqTKNsKu3dVJAmlp3EFhqv5T" ;
+  (* `P256K1, "r7c6teVRVw1OpWUM/xOx8D35Uiu9N9G2kEE54tPJRKw=" ;
+  `BRAINPOOLP256R1, "EwzWx38kl147Bi6yKer3sk8f1jMWOeCdgpd69QePBy0=" ;
+  `BRAINPOOLP384R1, "HComUhVG3jAHytfnHeIaoxV3ZMj5zHcLua8Z9pREnGNNlxtkgifHVXMRCa0wgWOh" ;
+  `BRAINPOOLP512R1, "CBRJFGHzV5TFOcXZvSrEXzfZp92sPUJi7Fb/Tgpv/QRdV72UYV8lUJ5WUv0uofVpumS3yA/2LrgJtanyN81cnw==" ; *)
 ]
 
 let tests =

--- a/tests/regression.ml
+++ b/tests/regression.ml
@@ -205,17 +205,21 @@ GjfhN8ieupCqSdF3iqDidK006KWs848y
     Private_key.decode_pem priv_data,
     Public_key.decode_pem pub_data
   with
-  | Ok (`P384 priv), Ok (`P384 pub) ->
-    let to_cs = Mirage_crypto_ec.P384.Dsa.pub_to_octets in
-    let pub' = Mirage_crypto_ec.P384.Dsa.pub_of_priv priv in
+  | Ok priv, Ok pub ->
+    Alcotest.(check bool __LOC__ true
+      ("p384" = Key_type.to_string (Private_key.key_type priv)));
+    Alcotest.(check bool __LOC__ true
+      ("p384" = Key_type.to_string (Public_key.key_type pub)));
+    let to_cs = Public_key.encode_der in
+    let pub' = Private_key.public priv in
     Alcotest.(check bool __LOC__ true (String.equal (to_cs pub) (to_cs pub')));
-    let pub_data' = Public_key.encode_pem (`P384 pub) in
+    let pub_data' = Public_key.encode_pem pub in
     Alcotest.(check bool __LOC__ true
                 (String.equal pub_data pub_data'));
-    let priv_data' = Private_key.encode_pem (`P384 priv) in
+    let priv_data' = Private_key.encode_pem priv in
     begin match Private_key.decode_pem priv_data' with
-      | Ok (`P384 priv) ->
-        let pub' = Mirage_crypto_ec.P384.Dsa.pub_of_priv priv in
+      | Ok priv ->
+        let pub' = Private_key.public priv in
         Alcotest.(check bool __LOC__ true
                     (String.equal (to_cs pub) (to_cs pub')))
       | _ -> Alcotest.failf "cannot decode re-encoded P384 private key"


### PR DESCRIPTION
This is a generic ECDSA implementation, that allows to register only the specific ECDSA implementation packages, that are actually required. This allows to remove unused curve implementations from the code base, but also to extend X509 with unusual curves, that are usually not available.