### PR TITLE
signing_request: return Error on an unknown CSR attribute instead of raising

### DIFF
--- a/lib/signing_request.ml
+++ b/lib/signing_request.ml
@@ -52,10 +52,11 @@ module Asn = struct
   open Registry
 
   let attributes =
-    let f = function[@ocaml.warning "-8"]
+    let f = function
       | (oid, [`C1 p]) when oid = PKCS9.challenge_password -> Ext.B (Password, p)
       | (oid, [`C1 n]) when oid = PKCS9.unstructured_name -> Ext.B (Name, n)
       | (oid, [`C2 es]) when oid = PKCS9.extension_request -> Ext.B (Extensions, es)
+      | _ -> parse_error "unsupported certificate request attribute"
     and g (Ext.B (k, v)) : Asn.oid * [ `C1 of string | `C2 of Extension.t ] list = match k, v with
       | Ext.Password, v -> (PKCS9.challenge_password, [`C1 v])
       | Ext.Name, v -> (PKCS9.unstructured_name, [`C1 v])


### PR DESCRIPTION
`decode_der` promises a `result`, but the attribute map function was marked `[@ocaml.warning "-8"]` and matched only the three known OIDs, so a valid CSR carrying any other attribute OID (or an unexpected value shape) raised `Match_failure` instead of `Error`. Add a catch-all that aborts the parse with `parse_error`, which `decode_der` turns into `Error (`Msg _)`.